### PR TITLE
WIP: URL query string reflects states

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6492,6 +6492,11 @@
       "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
       "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM="
     },
+    "url-search-params-polyfill": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/url-search-params-polyfill/-/url-search-params-polyfill-2.0.0.tgz",
+      "integrity": "sha1-gYuXu5FTllVXKPZGBPeJzqUY0NE="
+    },
     "user-home": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3727,6 +3727,11 @@
       "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.1.0.tgz",
       "integrity": "sha512-JK2bT5tZnLQlNuLa8pjOvUC/c/t4MfXBPZyrNK3C1BBxfX1rMHxFC2DvVCNd8esRjDtEddnwSTlv54sC5gvtMQ=="
     },
+    "leaflet-extra-markers": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/leaflet-extra-markers/-/leaflet-extra-markers-1.0.6.tgz",
+      "integrity": "sha1-6XUXAG0yfiWy4JvmOmgYcC9wrRY="
+    },
     "leven": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "redux-thunk": "2.2.0",
     "semantic-ui-css": "2.2.10",
     "semantic-ui-react": "0.70.0",
-    "tangram": "0.13.0"
+    "tangram": "0.13.0",
+    "url-search-params-polyfill": "2.0.0"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/src/components/App.test.js
+++ b/src/components/App.test.js
@@ -3,6 +3,7 @@ import React from 'react'
 import ReactDOM from 'react-dom'
 import App from './App'
 import { Tangram } from '../test/mocks'
+import 'url-search-params-polyfill'
 
 it('renders without crashing', () => {
   global.Tangram = Tangram

--- a/src/components/DatePickerContainer/index.js
+++ b/src/components/DatePickerContainer/index.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types'
 import { DateRangePicker, isInclusivelyBeforeDay } from 'react-dates'
 import moment from 'moment'
 import store from '../../store'
+import { getQueryStringObject, updateURL } from '../../url-state'
 import 'react-dates/lib/css/_datepicker.css'
 import './DatePickerContainer.css'
 
@@ -17,7 +18,24 @@ class DatePickerContainer extends React.Component {
     this.state = {
       focusedInput: null
     }
+
+    this.initDate()
     this.handleDateChange = this.handleDateChange.bind(this)
+  }
+
+  initDate (queryString = window.location.search) {
+    // If there is a query string, set datePickerComponent to display dates
+    // If there is a query string but no dates, set null
+    if (queryString.length > 0) {
+      const object = getQueryStringObject(queryString)
+      const startDate = Number(object.startDate) || null
+      const endDate = Number(object.endDate) || null
+      this.props.dispatch({
+        type: 'SET_DATE',
+        startDate,
+        endDate
+      })
+    }
   }
 
   handleDateChange (date) {
@@ -30,6 +48,12 @@ class DatePickerContainer extends React.Component {
       startDate: start,
       endDate: end
     })
+
+    const dateParam = {
+      startDate: start,
+      endDate: end
+    }
+    updateURL(dateParam)
   }
 
   render () {

--- a/src/components/DatePickerContainer/index.js
+++ b/src/components/DatePickerContainer/index.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types'
 import { DateRangePicker, isInclusivelyBeforeDay } from 'react-dates'
 import moment from 'moment'
 import store from '../../store'
-import { getQueryStringObject, updateURL } from '../../url-state'
+import { getQueryStringObject, updateURL, parseQueryString } from '../../url-state'
 import 'react-dates/lib/css/_datepicker.css'
 import './DatePickerContainer.css'
 
@@ -24,9 +24,8 @@ class DatePickerContainer extends React.Component {
   }
 
   initDate (queryString = window.location.search) {
-    // If there is a query string, set datePickerComponent to display dates
-    // If there is a query string but no dates, set null
-    if (queryString.length > 0) {
+    // If there is a start date, set values for date picker
+    if (parseQueryString('startDate') !== null) {
       const object = getQueryStringObject(queryString)
       const startDate = Number(object.startDate) || null
       const endDate = Number(object.endDate) || null

--- a/src/components/Map/index.js
+++ b/src/components/Map/index.js
@@ -3,6 +3,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { Map as Leaflet, ScaleControl } from 'react-leaflet'
 // import Tangram from 'tangram'
+import { updateURL } from '../../url-state'
 import 'leaflet/dist/leaflet.css'
 import './Map.css'
 
@@ -44,8 +45,29 @@ export default class Map extends React.Component {
     layer.addTo(this.map.leafletElement)
   }
 
+  // When map is dragged and lat/lng are changed, update URL to reflect change
+  // Not sure if config needs to be updated as well
+  handleDrag (event) {
+    const newCenter = event.target.getCenter()
+    const centerParams = {
+      lat: newCenter.lat.toFixed(4),
+      lng: newCenter.lng.toFixed(4)
+    }
+    updateURL(centerParams)
+  }
+
+  // When map is zoomed in/out, update URL to represent change
+  // Not sure if config needs to be update as well
+  handleZoom (event) {
+    const newZoom = event.target.getZoom()
+    const zoomParams = {
+      zoom: newZoom.toFixed(4)
+    }
+    updateURL(zoomParams)
+  }
+
   render () {
-    const { className, children, center, zoom, onChange, onClick } = this.props
+    const { className, children, center, zoom, onClick } = this.props
 
     return (
       <Leaflet
@@ -53,7 +75,8 @@ export default class Map extends React.Component {
         center={center}
         zoom={zoom}
         onClick={onClick}
-        onZoomEnd={(e) => onChange({ zoom: e.target._zoom })}
+        onZoomEnd={this.handleZoom}
+        onMoveEnd={this.handleDrag}
         ref={(ref) => { this.map = ref }}
       >
         <ScaleControl />

--- a/src/components/Map/index.js
+++ b/src/components/Map/index.js
@@ -53,7 +53,7 @@ export default class Map extends React.Component {
   }
 
   // When map is dragged and lat/lng are changed, update URL to reflect change
-  // Not sure if config needs to be updated as well
+  // Config is now also updated whenenver lat/lng is changed
   handleDrag (event) {
     const newCenter = event.target.getCenter()
     const zoom = event.target.getZoom()
@@ -66,7 +66,7 @@ export default class Map extends React.Component {
   }
 
   // When map is zoomed in/out, update URL to represent change
-  // Not sure if config needs to be update as well
+  // Config is now also updated whenever zoom is changed
   handleZoom (event) {
     const newZoom = event.target.getZoom()
     const center = event.target.getCenter()

--- a/src/components/Map/index.js
+++ b/src/components/Map/index.js
@@ -30,8 +30,7 @@ export default class Map extends React.Component {
   constructor (props) {
     super(props)
 
-    this.handleDrag = this.handleDrag.bind(this)
-    this.handleZoom = this.handleZoom.bind(this)
+    this.onChange = this.onChange.bind(this)
   }
 
   componentDidMount () {
@@ -52,29 +51,18 @@ export default class Map extends React.Component {
     layer.addTo(this.map.leafletElement)
   }
 
-  // When map is dragged and lat/lng are changed, update URL to reflect change
-  // Config is now also updated whenenver lat/lng is changed
-  handleDrag (event) {
+  // When map is dragged/zoomed and lat/lng/zoom are changed, update URL to reflect change
+  // Config is now also updated whenenver lat/lng/zoom are changed
+  onChange (event) {
     const newCenter = event.target.getCenter()
-    const zoom = event.target.getZoom()
+    const newZoom = event.target.getZoom()
     const centerParams = {
       lat: newCenter.lat.toFixed(4),
-      lng: newCenter.lng.toFixed(4)
-    }
-    updateURL(centerParams)
-    this.props.recenterMap(newCenter, zoom)
-  }
-
-  // When map is zoomed in/out, update URL to represent change
-  // Config is now also updated whenever zoom is changed
-  handleZoom (event) {
-    const newZoom = event.target.getZoom()
-    const center = event.target.getCenter()
-    const zoomParams = {
+      lng: newCenter.lng.toFixed(4),
       zoom: newZoom.toFixed(4)
     }
-    updateURL(zoomParams)
-    this.props.recenterMap(center, newZoom)
+    updateURL(centerParams)
+    this.props.recenterMap(newCenter, newZoom)
   }
 
   render () {
@@ -86,8 +74,7 @@ export default class Map extends React.Component {
         center={center}
         zoom={zoom}
         onClick={onClick}
-        onZoomEnd={this.handleZoom}
-        onMoveEnd={this.handleDrag}
+        onMoveEnd={this.onChange}
         ref={(ref) => { this.map = ref }}
       >
         <ScaleControl />

--- a/src/components/Map/index.js
+++ b/src/components/Map/index.js
@@ -27,6 +27,13 @@ export default class Map extends React.Component {
     onClick: function () {}
   }
 
+  constructor (props) {
+    super(props)
+
+    this.handleDrag = this.handleDrag.bind(this)
+    this.handleZoom = this.handleZoom.bind(this)
+  }
+
   componentDidMount () {
     const layer = Tangram.leafletLayer({
       scene: {
@@ -49,21 +56,25 @@ export default class Map extends React.Component {
   // Not sure if config needs to be updated as well
   handleDrag (event) {
     const newCenter = event.target.getCenter()
+    const zoom = event.target.getZoom()
     const centerParams = {
       lat: newCenter.lat.toFixed(4),
       lng: newCenter.lng.toFixed(4)
     }
     updateURL(centerParams)
+    this.props.recenterMap(newCenter, zoom)
   }
 
   // When map is zoomed in/out, update URL to represent change
   // Not sure if config needs to be update as well
   handleZoom (event) {
     const newZoom = event.target.getZoom()
+    const center = event.target.getCenter()
     const zoomParams = {
       zoom: newZoom.toFixed(4)
     }
     updateURL(zoomParams)
+    this.props.recenterMap(center, newZoom)
   }
 
   render () {

--- a/src/components/MapContainer.js
+++ b/src/components/MapContainer.js
@@ -53,11 +53,11 @@ class MapContainer extends React.Component {
 
       // If there is a mid waypoint, initialize mid_lat and mid_lng
       // If there is no mid waypoint, initialize to null to remove param from url query string
-      const mid_latlng = {
-        mid_lat: (numOfPoints > 2) ? waypoints[Math.floor(numOfPoints/2)].lat : null,
-        mid_lng: (numOfPoints > 2) ? waypoints[Math.floor(numOfPoints/2)].lng : null
+      const midLatLng = {
+        mid_lat: (numOfPoints > 2) ? waypoints[Math.floor(numOfPoints / 2)].lat : null,
+        mid_lng: (numOfPoints > 2) ? waypoints[Math.floor(numOfPoints / 2)].lng : null
       }
-      updateURL(mid_latlng)
+      updateURL(midLatLng)
     }
   }
 
@@ -81,26 +81,26 @@ class MapContainer extends React.Component {
       if (parseQueryString('st_lat') !== null) {
         // Getting start lat/lng and end lat/lng
         // Have to turn them into Leaflet's latlng object first
-        const st_latlng = L.latLng (
+        const stLatLng = L.latLng(
           Number(object.st_lat),
           Number(object.st_lng)
         )
-        const end_latlng = L.latLng (
+        const endLatLng = L.latLng(
           Number(object.end_lat),
           Number(object.end_lng)
         )
 
-        this.props.addWaypoint(st_latlng)
+        this.props.addWaypoint(stLatLng)
 
         if (parseQueryString('mid_lat') !== null) {
-          const mid_latlng = L.latLng (
+          const midLatLng = L.latLng(
             Number(object.mid_lat),
             Number(object.mid_lng)
           )
-          this.props.addWaypoint(mid_latlng)
+          this.props.addWaypoint(midLatLng)
         }
 
-        this.props.addWaypoint(end_latlng)
+        this.props.addWaypoint(endLatLng)
       }
 
       // Update redux store to display given params

--- a/src/components/MapContainer.js
+++ b/src/components/MapContainer.js
@@ -40,8 +40,15 @@ class MapContainer extends React.Component {
 
   initMap (queryString = window.location.search) {
     const { config } = this.props
-    // If query string exists (copy/paste url)
-    if (queryString.length > 0) {
+    // If bare url
+    if (queryString.length === 0) {
+      const initial = {
+        lat: config.map.center[0],
+        lng: config.map.center[1],
+        zoom: config.map.zoom
+      }
+      updateURL(initial)
+    } else { // If query string exists (copy/paste url)
       // Get necessary params
       const object = getQueryStringObject(queryString)
       const center = [Number(object.lat), Number(object.lng)]
@@ -51,14 +58,6 @@ class MapContainer extends React.Component {
       // Update redux store to display given params
       this.props.recenterMap(center, zoom)
       this.props.setLocation(center, label)
-    } else { // Else if bare URL
-      const initial = {
-        lat: config.map.center[0],
-        lng: config.map.center[1],
-        zoom: config.map.zoom
-      }
-      // Update URL to reflect config/initial states
-      updateURL(initial)
     }
   }
 

--- a/src/components/MapContainer.js
+++ b/src/components/MapContainer.js
@@ -46,7 +46,7 @@ class MapContainer extends React.Component {
       waypoints: []
     }
 
-    if (numOfPoints > 1) {
+    if (numOfPoints > 0) {
       for (var i = 0; i < numOfPoints; i++) {
         const lat = waypoints[i].lat.toFixed(4)
         const lng = waypoints[i].lng.toFixed(4)

--- a/src/components/MapContainer.js
+++ b/src/components/MapContainer.js
@@ -55,6 +55,10 @@ class MapContainer extends React.Component {
         points.waypoints.push(latlng)
       }
       updateURL(points)
+    } else { // If points all removed
+      // Remove waypoints from url query string
+      points.waypoints = null
+      updateURL(points)
     }
   }
 

--- a/src/components/MapSearchBar/index.js
+++ b/src/components/MapSearchBar/index.js
@@ -3,6 +3,7 @@ import Autosuggest from 'react-autosuggest'
 import PropTypes from 'prop-types'
 import { Icon } from 'semantic-ui-react'
 import { throttle } from 'lodash'
+import { updateURL, parseQueryString } from '../../url-state'
 import './MapSearchBar.css'
 
 class MapSearchBar extends React.Component {
@@ -32,6 +33,17 @@ class MapSearchBar extends React.Component {
     this.onSuggestionSelected = this.onSuggestionSelected.bind(this)
     this.handleSubmit = this.handleSubmit.bind(this)
     this.search = this.search.bind(this)
+  }
+
+  componentDidMount () {
+    // Not sure if right lifecycle
+    // If queryString has value for label, set value on MapSearchBar
+    const newValue = parseQueryString('label')
+    if (newValue !== null) {
+      this.setState({
+        value: newValue
+      })
+    }
   }
 
   // Will be called every time you need to recalculate suggestions
@@ -64,6 +76,14 @@ class MapSearchBar extends React.Component {
     this.props.setLocation(latlng, suggestionValue)
     // Recenters map to the selected location's latlng
     this.props.recenterMap(latlng)
+
+    // Updating URL to represent new lat/lng coordinates and new label
+    const centerParams = {
+      lat: lat,
+      lng: lng,
+      label: suggestionValue
+    }
+    updateURL(centerParams)
   }
 
   renderSuggestion (suggestion, {query, isHighlighted}) {

--- a/src/components/MapSearchBar/index.js
+++ b/src/components/MapSearchBar/index.js
@@ -75,7 +75,13 @@ class MapSearchBar extends React.Component {
     // Stores latlng and name of selected location in Redux
     this.props.setLocation(latlng, suggestionValue)
     // Recenters map to the selected location's latlng
-    this.props.recenterMap(latlng, 3)
+    const zoom = this.props.config.map.zoom
+    // If user is below zoom 10, set to 10
+    if (zoom < 10) {
+      this.props.recenterMap(latlng, 10)
+    } else {
+      this.props.recenterMap(latlng, zoom)
+    }
 
     // Updating URL to represent new lat/lng coordinates and new label
     const centerParams = {

--- a/src/components/MapSearchBar/index.js
+++ b/src/components/MapSearchBar/index.js
@@ -15,8 +15,10 @@ class MapSearchBar extends React.Component {
 
   constructor (props) {
     super(props)
+
+    const newValue = parseQueryString('label')
     this.state = {
-      value: '',
+      value: newValue || '',
       placeholder: 'Search for an address or a place',
       suggestions: []
     }
@@ -33,17 +35,6 @@ class MapSearchBar extends React.Component {
     this.onSuggestionSelected = this.onSuggestionSelected.bind(this)
     this.handleSubmit = this.handleSubmit.bind(this)
     this.search = this.search.bind(this)
-  }
-
-  componentDidMount () {
-    // Not sure if right lifecycle
-    // If queryString has value for label, set value on MapSearchBar
-    const newValue = parseQueryString('label')
-    if (newValue !== null) {
-      this.setState({
-        value: newValue
-      })
-    }
   }
 
   // Will be called every time you need to recalculate suggestions
@@ -82,14 +73,8 @@ class MapSearchBar extends React.Component {
     } else {
       this.props.recenterMap(latlng, zoom)
     }
-
-    // Updating URL to represent new lat/lng coordinates and new label
-    const centerParams = {
-      lat: lat,
-      lng: lng,
-      label: suggestionValue
-    }
-    updateURL(centerParams)
+    // Updating URL with suggestion value
+    updateURL({label: suggestionValue})
   }
 
   renderSuggestion (suggestion, {query, isHighlighted}) {
@@ -149,12 +134,14 @@ class MapSearchBar extends React.Component {
   }
 
   clearSearch (event) {
-    // set state value back to empty string
+    // Set state value back to empty string
     this.setState({
       value: ''
     })
-    // clears suggestions
+    // Clears suggestions
     this.onSuggestionsClearRequested()
+    // Clear suggestion value from URL
+    updateURL({label: null})
   }
 
   // Now Autosuggest component is wrapped in a form so that when 'enter' is pressed, suggestions container is not closed automatically

--- a/src/components/MapSearchBar/index.js
+++ b/src/components/MapSearchBar/index.js
@@ -75,7 +75,7 @@ class MapSearchBar extends React.Component {
     // Stores latlng and name of selected location in Redux
     this.props.setLocation(latlng, suggestionValue)
     // Recenters map to the selected location's latlng
-    this.props.recenterMap(latlng)
+    this.props.recenterMap(latlng, 3)
 
     // Updating URL to represent new lat/lng coordinates and new label
     const centerParams = {

--- a/src/store/actions/index.js
+++ b/src/store/actions/index.js
@@ -1,8 +1,9 @@
 // recenters map when location chosen from MapSearchBar
-export function recenterMap (coordinates) {
+export function recenterMap (coordinates, zoom) {
   return {
     type: 'CHANGE_CENTER',
-    coordinates
+    coordinates,
+    zoom
   }
 }
 

--- a/src/store/reducers/config.js
+++ b/src/store/reducers/config.js
@@ -6,7 +6,8 @@ const config = (state = initialState, action) => {
       return {
         ...state,
         map: {
-          center: action.coordinates
+          center: action.coordinates,
+          zoom: action.zoom
         }
       }
     default:

--- a/src/url-state.js
+++ b/src/url-state.js
@@ -35,7 +35,7 @@ export function addNewParam (params = {}, queryString = window.location.search) 
     } else {
       searchParams.set(key, value)
     }
-  })
+  }
 
   const newQueryString = `?${searchParams.toString()}`
   return newQueryString

--- a/src/url-state.js
+++ b/src/url-state.js
@@ -1,0 +1,49 @@
+// Turn query string into an object with key/value
+export function getQueryStringObject (queryString = window.location.search) {
+  const params = new window.URLSearchParams(queryString)
+  const queryObject = {}
+
+  for (const param of params.entries()) {
+    const [key, value] = param
+
+    // Do not add to object if key is blank string or value is undefined
+    if (key !== '' && typeof value !== 'undefined') {
+      queryObject[key] = value
+    }
+  }
+
+  return queryObject
+}
+
+// Parsing query string to return certain parameter
+export function parseQueryString (param, queryString = window.location.search) {
+  const params = new window.URLSearchParams(queryString)
+  return params.get(param)
+}
+
+// Adding new parameter to query string
+// If no query string, empty URLSearchParams object is created
+export function addNewParam (params = {}, queryString = window.location.search) {
+  const searchParams = new window.URLSearchParams(queryString)
+
+  Object.entries(params).forEach((param) => {
+    const [key, value] = param
+
+    // If no value, delete key
+    if (value === null) {
+      searchParams.delete(key)
+    } else {
+      searchParams.set(key, value)
+    }
+  })
+
+  const newQueryString = `?${searchParams.toString()}`
+  return newQueryString
+}
+
+// Replace existing history state
+export function updateURL (params = {}) {
+  const locationPrefix = window.location.pathname
+  const queryString = addNewParam(params)
+  window.history.replaceState({}, null, locationPrefix + queryString)
+}

--- a/src/url-state.js
+++ b/src/url-state.js
@@ -26,8 +26,8 @@ export function parseQueryString (param, queryString = window.location.search) {
 export function addNewParam (params = {}, queryString = window.location.search) {
   const searchParams = new URLSearchParams(queryString)
 
-  Object.entries(params).forEach((param) => {
-    const [key, value] = param
+  for (var param in params) {
+    const [key, value] = [param, params[param]]
 
     // If no value, delete key
     if (value === null) {

--- a/src/url-state.js
+++ b/src/url-state.js
@@ -1,6 +1,6 @@
 // Turn query string into an object with key/value
 export function getQueryStringObject (queryString = window.location.search) {
-  const params = new URLSearchParams(queryString)
+  const params = new window.URLSearchParams(queryString)
   const queryObject = {}
 
   for (const param of params.entries()) {
@@ -17,14 +17,14 @@ export function getQueryStringObject (queryString = window.location.search) {
 
 // Parsing query string to return certain parameter
 export function parseQueryString (param, queryString = window.location.search) {
-  const params = new URLSearchParams(queryString)
+  const params = new window.URLSearchParams(queryString)
   return params.get(param)
 }
 
 // Adding new parameter to query string
 // If no query string, empty URLSearchParams object is created
 export function addNewParam (params = {}, queryString = window.location.search) {
-  const searchParams = new URLSearchParams(queryString)
+  const searchParams = new window.URLSearchParams(queryString)
 
   for (var param in params) {
     const [key, value] = [param, params[param]]

--- a/src/url-state.js
+++ b/src/url-state.js
@@ -1,6 +1,6 @@
 // Turn query string into an object with key/value
 export function getQueryStringObject (queryString = window.location.search) {
-  const params = new window.URLSearchParams(queryString)
+  const params = new URLSearchParams(queryString)
   const queryObject = {}
 
   for (const param of params.entries()) {
@@ -17,14 +17,14 @@ export function getQueryStringObject (queryString = window.location.search) {
 
 // Parsing query string to return certain parameter
 export function parseQueryString (param, queryString = window.location.search) {
-  const params = new window.URLSearchParams(queryString)
+  const params = new URLSearchParams(queryString)
   return params.get(param)
 }
 
 // Adding new parameter to query string
 // If no query string, empty URLSearchParams object is created
 export function addNewParam (params = {}, queryString = window.location.search) {
-  const searchParams = new window.URLSearchParams(queryString)
+  const searchParams = new URLSearchParams(queryString)
 
   Object.entries(params).forEach((param) => {
     const [key, value] = param
@@ -47,3 +47,4 @@ export function updateURL (params = {}) {
   const queryString = addNewParam(params)
   window.history.replaceState({}, null, locationPrefix + queryString)
 }
+

--- a/src/url-state.js
+++ b/src/url-state.js
@@ -47,4 +47,3 @@ export function updateURL (params = {}) {
   const queryString = addNewParam(params)
   window.history.replaceState({}, null, locationPrefix + queryString)
 }
-


### PR DESCRIPTION
URL query string currently displays the lat/lng and zoom of map (Issue #10), waypoints of route, start and end dates of daterangepicker, and the label/value of mapsearchbar (Issue #9). 
Initialization of states based on these params are working. Also fixed it so that zoom default is 10 for when suggestion is selected in map search bar (Issue #28)

I didn't implement the route/network mode, time filters, and view options into the query string since we currently don't have those things in the application. I also haven't figured out what is expected for back/forward and history entries so I will do that after I'm more sure. 
