### PR TITLE
Fixed bug

### DIFF
--- a/src/components/MapSearchBar/index.js
+++ b/src/components/MapSearchBar/index.js
@@ -136,7 +136,9 @@ class MapSearchBar extends React.Component {
   handleSubmit (event) {
     event.preventDefault()
     const inputValue = this.autosuggestBar.input.value
-    this.search(inputValue)
+    if (inputValue !== '') {
+      this.search(inputValue)
+    }
   }
 
   render () {


### PR DESCRIPTION
When 'enter' is pressed on an empty search bar, a request is no longer sent to mapzen search 
Issue #32