### PR TITLE
Refactor store; remove ducks; standardize syntax

### DIFF
--- a/src/components/Map/index.js
+++ b/src/components/Map/index.js
@@ -17,7 +17,8 @@ export default class Map extends React.Component {
     center: PropTypes.array,
     zoom: PropTypes.number,
     onChange: PropTypes.func,
-    onClick: PropTypes.func
+    onClick: PropTypes.func,
+    recenterMap: PropTypes.func
   }
 
   static defaultProps = {

--- a/src/components/MapContainer.js
+++ b/src/components/MapContainer.js
@@ -10,8 +10,8 @@ import RouteLine from './Map/RouteLine'
 import RouteError from './Map/RouteError'
 import { getRoute, valhallaResponseToPolylineCoordinates } from '../lib/valhalla'
 import { getNewWaypointPosition } from '../lib/routing'
-import * as actionCreators from '../store/actions'
-import * as routeActionCreators from '../store/reducers/route'
+import * as mapActionCreators from '../store/actions/map'
+import * as routeActionCreators from '../store/actions/route'
 import { updateURL } from '../lib/url-state'
 
 class MapContainer extends React.Component {
@@ -19,7 +19,7 @@ class MapContainer extends React.Component {
     className: PropTypes.string,
     config: PropTypes.object,
     route: PropTypes.object,
-    mapLocation: PropTypes.object
+    map: PropTypes.object
   }
 
   constructor (props) {
@@ -121,14 +121,14 @@ class MapContainer extends React.Component {
 
   render () {
     const config = this.props.config
-    const mapLocation = this.props.mapLocation
+    const map = this.props.map
 
     return (
       <div className={this.props.className}>
         <MapSearchBar config={config} setLocation={this.props.setLocation} recenterMap={this.props.recenterMap} />
         <Map
           config={config}
-          center={mapLocation.coordinates}
+          center={map.coordinates}
           zoom={config.map.zoom}
           onClick={this.onClick}
           recenterMap={this.props.recenterMap}
@@ -150,12 +150,12 @@ function mapStateToProps (state) {
   return {
     config: state.config,
     route: state.route,
-    mapLocation: state.mapLocation
+    map: state.map
   }
 }
 
 function mapDispatchToProps (dispatch) {
-  return bindActionCreators({ ...actionCreators, ...routeActionCreators }, dispatch)
+  return bindActionCreators({ ...mapActionCreators, ...routeActionCreators }, dispatch)
 }
 
 export default connect(mapStateToProps, mapDispatchToProps)(MapContainer)

--- a/src/init.js
+++ b/src/init.js
@@ -1,8 +1,9 @@
 import L from 'leaflet'
-import * as actionCreators from './store/actions'
-import * as routeActionCreators from './store/reducers/route'
-import store from './store'
 import config from './config'
+import store from './store'
+import { recenterMap, setLocation } from './store/actions/map'
+import { setDate } from './store/actions/date'
+import { addWaypoint } from './store/actions/route'
 import { getQueryStringObject, updateURL, parseQueryString } from './lib/url-state'
 
 // Initialize application based on url query string params
@@ -26,11 +27,11 @@ export function initApp (queryString = window.location.search) {
     updateURL(mapView)
   }
   // Initializing lat/lng and zoom
-  store.dispatch(actionCreators.recenterMap(coordinates, mapView.zoom))
+  store.dispatch(recenterMap(coordinates, mapView.zoom))
   // Initializing map search bar
-  store.dispatch(actionCreators.setLocation(coordinates, label))
+  store.dispatch(setLocation(coordinates, label))
   // Initializing dates
-  store.dispatch(actionCreators.setDate(date.startDate, date.endDate))
+  store.dispatch(setDate(date.startDate, date.endDate))
   // Initializing markers and route
   initRoute(object)
 }
@@ -48,7 +49,7 @@ export function initRoute (queryObject) {
         Number(latlng[1])
       )
       // Add waypoint to route
-      store.dispatch(routeActionCreators.addWaypoint(point))
+      store.dispatch(addWaypoint(point))
     }
   }
 }

--- a/src/store/actions/date.js
+++ b/src/store/actions/date.js
@@ -1,0 +1,9 @@
+import { SET_DATE } from '../actions'
+
+export function setDate (startDate, endDate) {
+  return {
+    type: SET_DATE,
+    startDate,
+    endDate
+  }
+}

--- a/src/store/actions/errors.js
+++ b/src/store/actions/errors.js
@@ -1,0 +1,22 @@
+import { ADD_ERROR, REMOVE_ERROR, CLEAR_ERRORS } from '../actions'
+
+// Action creators
+export function addError (error) {
+  return {
+    type: ADD_ERROR,
+    error
+  }
+}
+
+export function removeError (error) {
+  return {
+    type: REMOVE_ERROR,
+    error
+  }
+}
+
+export function clearErrors () {
+  return {
+    type: CLEAR_ERRORS
+  }
+}

--- a/src/store/actions/index.js
+++ b/src/store/actions/index.js
@@ -1,25 +1,21 @@
-// recenters map when location chosen from MapSearchBar
-export function recenterMap (coordinates, zoom) {
-  return {
-    type: 'CHANGE_CENTER',
-    coordinates,
-    zoom
-  }
-}
+/* date */
+export const SET_DATE = 'SET_DATE'
 
-// stores lat and lng of new location from MapSearchBar
-export function setLocation (latlng, name) {
-  return {
-    type: 'SET_LOCATION',
-    latlng,
-    name
-  }
-}
+/* errors */
+export const ADD_ERROR = 'ADD_ERROR'
+export const REMOVE_ERROR = 'REMOVE_ERROR'
+export const CLEAR_ERRORS = 'CLEAR_ERRORS'
 
-export function setDate (startDate, endDate) {
-  return {
-    type: 'SET_DATE',
-    startDate,
-    endDate
-  }
-}
+/* map */
+export const SET_MAP_LOCATION = 'SET_MAP_LOCATION'
+export const SET_MAP_VIEW = 'SET_MAP_VIEW'
+
+/* route */
+export const ADD_ROUTE_WAYPOINT = 'ADD_ROUTE_WAYPOINT'
+export const REMOVE_ROUTE_WAYPOINT = 'REMOVE_ROUTE_WAYPOINT'
+export const UPDATE_ROUTE_WAYPOINT = 'UPDATE_ROUTE_WAYPOINT'
+export const INSERT_ROUTE_WAYPOINT = 'INSERT_ROUTE_WAYPOINT'
+export const SET_ROUTE = 'SET_ROUTE'
+export const SET_ROUTE_ERROR = 'SET_ROUTE_ERROR'
+
+export const CLEAR_ANALYSIS_MODE = 'CLEAR_ANALYSIS_MODE'

--- a/src/store/actions/map.js
+++ b/src/store/actions/map.js
@@ -1,0 +1,19 @@
+import { SET_MAP_LOCATION, SET_MAP_VIEW } from '../actions'
+
+// stores lat and lng of new location from MapSearchBar
+export function setLocation (latlng, name) {
+  return {
+    type: SET_MAP_LOCATION,
+    latlng,
+    name
+  }
+}
+
+// recenters map when location chosen from MapSearchBar
+export function recenterMap (coordinates, zoom) {
+  return {
+    type: SET_MAP_VIEW,
+    coordinates,
+    zoom
+  }
+}

--- a/src/store/actions/route.js
+++ b/src/store/actions/route.js
@@ -1,0 +1,71 @@
+import {
+  ADD_ROUTE_WAYPOINT,
+  REMOVE_ROUTE_WAYPOINT,
+  UPDATE_ROUTE_WAYPOINT,
+  INSERT_ROUTE_WAYPOINT,
+  SET_ROUTE,
+  SET_ROUTE_ERROR,
+  CLEAR_ANALYSIS_MODE
+} from '../actions'
+
+export function addWaypoint (waypoint) {
+  return {
+    type: ADD_ROUTE_WAYPOINT,
+    waypoint
+  }
+}
+
+export function removeWaypoint (waypoint) {
+  return {
+    type: REMOVE_ROUTE_WAYPOINT,
+    waypoint
+  }
+}
+
+export function updateWaypoint (oldWaypoint, newWaypoint) {
+  return {
+    type: UPDATE_ROUTE_WAYPOINT,
+    oldWaypoint,
+    newWaypoint
+  }
+}
+
+export function insertWaypoint (waypoint, insertAfter) {
+  return {
+    type: INSERT_ROUTE_WAYPOINT,
+    waypoint,
+    index: insertAfter + 1
+  }
+}
+
+export function setRoute (latlngs) {
+  return {
+    type: SET_ROUTE,
+    lineCoordinates: latlngs
+  }
+}
+
+export function clearRoute () {
+  return {
+    type: SET_ROUTE,
+    lineCoordinates: []
+  }
+}
+
+export function setRouteError (message) {
+  return {
+    type: SET_ROUTE_ERROR,
+    error: message
+  }
+}
+
+export function clearRouteError () {
+  return {
+    type: SET_ROUTE_ERROR,
+    error: null
+  }
+}
+
+export function resetRoute () {
+  return { type: CLEAR_ANALYSIS_MODE }
+}

--- a/src/store/reducers/config.js
+++ b/src/store/reducers/config.js
@@ -1,8 +1,9 @@
 import initialState from '../../config'
+import { SET_MAP_VIEW } from '../actions'
 
 const config = (state = initialState, action) => {
   switch (action.type) {
-    case 'CHANGE_CENTER':
+    case SET_MAP_VIEW:
       return {
         ...state,
         map: {

--- a/src/store/reducers/date.js
+++ b/src/store/reducers/date.js
@@ -1,3 +1,5 @@
+import { SET_DATE } from '../actions'
+
 const initialState = {
   startDate: null,
   endDate: null
@@ -5,7 +7,7 @@ const initialState = {
 
 const date = (state = initialState, action) => {
   switch (action.type) {
-    case 'SET_DATE':
+    case SET_DATE:
       return {
         ...state,
         startDate: action.startDate,

--- a/src/store/reducers/errors.js
+++ b/src/store/reducers/errors.js
@@ -1,11 +1,6 @@
 import { uniqWith, reject, isEqual } from 'lodash'
+import { ADD_ERROR, REMOVE_ERROR, CLEAR_ERRORS } from '../actions'
 
-// Actions
-export const ADD_ERROR = 'analyst-ui/errors/ADD_ERROR'
-export const REMOVE_ERROR = 'analyst-ui/errors/REMOVE_ERROR'
-export const CLEAR_ERRORS = 'analyst-ui/errors/CLEAR_ERRORS'
-
-// Reducer
 const initialState = {
   errors: []
 }
@@ -36,24 +31,3 @@ const errors = (state = initialState, action) => {
 }
 
 export default errors
-
-// Action creators
-export function addError (error) {
-  return {
-    type: ADD_ERROR,
-    error
-  }
-}
-
-export function removeError (error) {
-  return {
-    type: REMOVE_ERROR,
-    error
-  }
-}
-
-export function clearErrors () {
-  return {
-    type: CLEAR_ERRORS
-  }
-}

--- a/src/store/reducers/index.js
+++ b/src/store/reducers/index.js
@@ -2,14 +2,14 @@ import { combineReducers } from 'redux'
 import config from './config'
 import date from './date'
 import errors from './errors'
+import map from './map'
 import route from './route'
-import mapLocation from './mapLocation'
 
 const reducers = combineReducers({
   config,
   date,
   errors,
-  mapLocation,
+  map,
   route
 })
 

--- a/src/store/reducers/map.js
+++ b/src/store/reducers/map.js
@@ -1,13 +1,14 @@
 import config from '../../config'
+import { SET_MAP_LOCATION } from '../actions'
 
 const initialState = {
   coordinates: config.map.center,
   label: ''
 }
 
-const mapLocation = (state = initialState, action) => {
+const map = (state = initialState, action) => {
   switch (action.type) {
-    case 'SET_LOCATION':
+    case SET_MAP_LOCATION:
       return {
         ...state,
         coordinates: action.latlng,
@@ -18,4 +19,4 @@ const mapLocation = (state = initialState, action) => {
   }
 }
 
-export default mapLocation
+export default map

--- a/src/store/reducers/route.js
+++ b/src/store/reducers/route.js
@@ -1,36 +1,33 @@
 import { isEqual } from 'lodash'
+import {
+  ADD_ROUTE_WAYPOINT,
+  REMOVE_ROUTE_WAYPOINT,
+  UPDATE_ROUTE_WAYPOINT,
+  INSERT_ROUTE_WAYPOINT,
+  SET_ROUTE,
+  SET_ROUTE_ERROR,
+  CLEAR_ANALYSIS_MODE
+} from '../actions'
 
-// Experimental: try Ducks (https://github.com/erikras/ducks-modular-redux)
-
-// Actions
-const ADD_WAYPOINT = 'analyst-ui/route/ADD_WAYPOINT'
-const REMOVE_WAYPOINT = 'analyst-ui/route/REMOVE_WAYPOINT'
-const UPDATE_WAYPOINT = 'analyst-ui/route/UPDATE_WAYPOINT'
-const INSERT_WAYPOINT = 'analyst-ui/route/INSERT_WAYPOINT'
-const SET_ROUTE = 'analyst-ui/route/SET_ROUTE'
-const SET_ROUTE_ERROR = 'analyst-ui/route/SET_ROUTE_ERROR'
-const RESET = 'analyst-ui/route/RESET'
-
-// Reducer
 const initialState = {
   waypoints: [],
   lineCoordinates: [],
   error: null
 }
 
-export default function reducer (state = initialState, action) {
+const route = (state = initialState, action) => {
   switch (action.type) {
-    case ADD_WAYPOINT:
+    case ADD_ROUTE_WAYPOINT:
       return {
         ...state,
         waypoints: [...state.waypoints, action.waypoint]
       }
-    case REMOVE_WAYPOINT:
+    case REMOVE_ROUTE_WAYPOINT:
       return {
         ...state,
         waypoints: state.waypoints.filter(waypoint => waypoint !== action.waypoint)
       }
-    case UPDATE_WAYPOINT: {
+    case UPDATE_ROUTE_WAYPOINT: {
       const copy = [...state.waypoints]
       for (let i = 0; i < copy.length; i++) {
         if (isEqual(copy[i], action.oldWaypoint)) {
@@ -43,7 +40,7 @@ export default function reducer (state = initialState, action) {
         waypoints: copy
       }
     }
-    case INSERT_WAYPOINT:
+    case INSERT_ROUTE_WAYPOINT:
       return {
         ...state,
         waypoints: [
@@ -64,74 +61,11 @@ export default function reducer (state = initialState, action) {
         lineCoordinates: [],
         error: action.error
       }
-    case RESET:
+    case CLEAR_ANALYSIS_MODE:
       return initialState
     default:
       return state
   }
 }
 
-// Action creators
-export function addWaypoint (waypoint) {
-  return {
-    type: ADD_WAYPOINT,
-    waypoint
-  }
-}
-
-export function removeWaypoint (waypoint) {
-  return {
-    type: REMOVE_WAYPOINT,
-    waypoint
-  }
-}
-
-export function updateWaypoint (oldWaypoint, newWaypoint) {
-  return {
-    type: UPDATE_WAYPOINT,
-    oldWaypoint,
-    newWaypoint
-  }
-}
-
-export function insertWaypoint (waypoint, insertAfter) {
-  return {
-    type: INSERT_WAYPOINT,
-    waypoint,
-    index: insertAfter + 1
-  }
-}
-
-export function setRoute (latlngs) {
-  return {
-    type: SET_ROUTE,
-    lineCoordinates: latlngs
-  }
-}
-
-export function clearRoute () {
-  return {
-    type: SET_ROUTE,
-    lineCoordinates: []
-  }
-}
-
-export function setRouteError (message) {
-  return {
-    type: SET_ROUTE_ERROR,
-    error: message
-  }
-}
-
-export function clearRouteError () {
-  return {
-    type: SET_ROUTE_ERROR,
-    error: null
-  }
-}
-
-export function resetRoute () {
-  return { type: RESET }
-}
-
-// Thunks
+export default route


### PR DESCRIPTION
At the beginning of this project I was giving [Ducks](https://github.com/erikras/ducks-modular-redux) a try -- it's an alternative strategy to getting around some of the [boilerplate](http://redux.js.org/docs/recipes/ReducingBoilerplate.html) that idiomatic Redux asks you to write.

Dan Abramov (creator of Redux) has said he does not necessarily approve of Ducks because it can enforce a [1:1 relationship between actions and reducers](https://twitter.com/dan_abramov/status/738405796770353152) and I've now hit on a scenario (in another branch) where this becomes a problem. For instance, say we issue a `RESET_EVERYTHING` action. Different reducers should be able to listen for this action so that each of them can clear their state. But in the Ducks format, there's no idiomatic way to store shared actions. We could presumably create a shared action module to import from.

However, Ducks was not used as a standard throughout, so rather than convert everything to Ducks and then work around its issues, I've decided to drop it entirely and go back to plain ol' Redux. Ideally this is better for maintainability, if a little more verbose, in that everything one needs to maintain the Redux store can be gleaned from the regular Redux documentation. This might not hold 100% true moving forward, but I'm comfortable making this reset for the time being.

This PR removes Ducks, and standardizes some of the Redux syntax to be consistent throughout.