### PR TITLE
Geocoder is now expandable 

### DIFF
--- a/src/components/MapSearchBar/MapSearchBar.css
+++ b/src/components/MapSearchBar/MapSearchBar.css
@@ -1,26 +1,41 @@
 .map-search-panel {
   position: absolute;
-  right: 0;
-  margin: 10px;
+  left: 0;
+  margin: 12px;
   z-index: 1000;
 }
 
-.search-icon {
-  height: 25px;
+.ui.icon.button.search-button {
   position: absolute;
-  padding: 7px 10px;
-  margin: 10px;
+  background: white;
+  color: black;
+  width: 30px;
+  height: 35px;
+  padding: 0.6em;
+  border: solid 1px rgba(0,0,0,0.2);
+  border-right: none;
+  border-radius: 4px;
+  z-index: 1000;
 }
 
 .close.icon.clear-search {
   position: absolute;
-  right: 0;
+  left: 290px;
   margin: 8px;
   cursor: pointer;
+  z-index: 1000;
 }
 
 .close.icon.clear-search:hover {
   color: #c9caca;
+}
+
+.leaflet-top .leaflet-control {
+  margin-top: 55px;
+}
+
+.inputContainer {
+  display: none;
 }
 
 .react-autosuggest__input--focused {
@@ -28,16 +43,17 @@
 }
 
 .react-autosuggest__input {
-  width: 330px;
+  position: absolute;
+  top: 0;
+  width: 320px;
   height: 35px;
-  padding: 10px 30px;
+  padding: 10px 35px;
   padding-right: 25px;
   font-family: Lato;
   font-weight: 300;
   font-size: 14px;
   border: 1px solid rgba(0,0,0,0.2);
   border-radius: 4px;
-  z-index: 1000;
 }
 
 .react-autosuggest__input--open {
@@ -53,7 +69,8 @@
   display: block;
   position: absolute;
   top: 35px;
-  width: 330px;
+  left: 45px;
+  width: 275px;
   border: 1px solid rgba(0,0,0,0.2);
   background-color: #fff;
   font-family: Lato;

--- a/src/components/MapSearchBar/MapSearchBar.css
+++ b/src/components/MapSearchBar/MapSearchBar.css
@@ -5,17 +5,30 @@
   z-index: 1000;
 }
 
+i.icon.search-icon {
+  font-size: 1.2em;
+}
+
 .ui.icon.button.search-button {
   position: absolute;
   background: white;
   color: black;
   width: 30px;
-  height: 35px;
-  padding: 0.6em;
+  height: 30px;
+  padding: 0.5em;
   border: solid 1px rgba(0,0,0,0.2);
   border-right: none;
   border-radius: 4px;
   z-index: 1000;
+}
+
+.ui.icon.button.search-button.search-bar__expanded {
+  height: 35px;
+  width: 35px;
+}
+
+.ui.icon.button.search-button:hover {
+  background: #f4f4f4;
 }
 
 .close.icon.clear-search {
@@ -38,6 +51,10 @@
   display: none;
 }
 
+.inputContainer.search-bar__expanded {
+  display: block;
+}
+
 .react-autosuggest__input--focused {
   outline: none;
 }
@@ -47,7 +64,7 @@
   top: 0;
   width: 320px;
   height: 35px;
-  padding: 10px 35px;
+  padding: 10px 40px;
   padding-right: 25px;
   font-family: Lato;
   font-weight: 300;
@@ -72,7 +89,7 @@
   left: 45px;
   width: 275px;
   border: 1px solid rgba(0,0,0,0.2);
-  background-color: #fff;
+  background-color: rgba(255,255,255,0.90);
   font-family: Lato;
   font-weight: 300;
   font-size: 14px;
@@ -89,7 +106,7 @@
 
 .react-autosuggest__suggestion {
   cursor: pointer;
-  padding: 10px 15px;
+  padding: 8px 10px;
   border-bottom: solid 1px #c9caca;
 }
 

--- a/src/components/MapSearchBar/index.js
+++ b/src/components/MapSearchBar/index.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import Autosuggest from 'react-autosuggest'
 import PropTypes from 'prop-types'
-import { Icon } from 'semantic-ui-react'
+import { Button, Icon } from 'semantic-ui-react'
 import { throttle } from 'lodash'
 import { updateURL, parseQueryString } from '../../lib/url-state'
 import './MapSearchBar.css'
@@ -35,6 +35,7 @@ class MapSearchBar extends React.Component {
     this.onSuggestionSelected = this.onSuggestionSelected.bind(this)
     this.handleSubmit = this.handleSubmit.bind(this)
     this.search = this.search.bind(this)
+    this.handleClick = this.handleClick.bind(this)
   }
 
   // Will be called every time you need to recalculate suggestions
@@ -154,20 +155,30 @@ class MapSearchBar extends React.Component {
     }
   }
 
+  handleClick (event) {
+    const button = (event.target.nextSibling === null) ? event.target.parentElement : event.target
+    const inputContainer = button.nextSibling
+    if (inputContainer.style.display === 'block') {
+      inputContainer.style.display = "none"
+    } else {
+      inputContainer.style.display = "block"
+    }
+  }
+
   render () {
     const inputProps = {
       placeholder: this.state.placeholder,
       value: this.state.value,
       onChange: this.onChangeAutosuggest
     }
-
     const inputVal = this.state.value
 
     return (
       <div className="map-search-panel">
-        <Icon name="search" className="search-icon" />
-        {this.renderClearButton(inputVal)}
-        <form onSubmit={this.handleSubmit}>
+        <Button icon size="tiny" className="search-button" onClick={this.handleClick}>
+          <Icon name="search" className="search-icon" />
+        </Button>
+        <form onSubmit={this.handleSubmit} className="inputContainer">
           <Autosuggest
             ref={(ref) => { this.autosuggestBar = ref }}
             suggestions={this.state.suggestions}
@@ -178,6 +189,7 @@ class MapSearchBar extends React.Component {
             renderSuggestion={this.renderSuggestion}
             inputProps={inputProps}
           />
+          {this.renderClearButton(inputVal)}
         </form>
       </div>
     )

--- a/src/components/MapSearchBar/index.js
+++ b/src/components/MapSearchBar/index.js
@@ -38,6 +38,13 @@ class MapSearchBar extends React.Component {
     this.handleClick = this.handleClick.bind(this)
   }
 
+  componentDidMount () {
+    // If link has label query, display search bar and expand search icon to fit search bar
+    if (this.state.value !== '') {
+      this.refs.searchBar.classList.add('search-bar__expanded')
+      this.refs.searchButton.ref.classList.add('search-bar__expanded')
+    }
+  }
   // Will be called every time you need to recalculate suggestions
   onSuggestionsFetchRequested ({value}) {
     if (value.length >= 2) {
@@ -155,14 +162,13 @@ class MapSearchBar extends React.Component {
     }
   }
 
+  // When search button is clicked, autosuggest bar gets displayed
   handleClick (event) {
-    const button = (event.target.nextSibling === null) ? event.target.parentElement : event.target
-    const inputContainer = button.nextSibling
-    if (inputContainer.style.display === 'block') {
-      inputContainer.style.display = "none"
-    } else {
-      inputContainer.style.display = "block"
-    }
+    const searchButton = this.refs.searchButton.ref
+    const inputContainer = this.refs.searchBar
+    // Display search bar and expand search icon size when clicked on
+    inputContainer.classList.toggle('search-bar__expanded')
+    searchButton.classList.toggle('search-bar__expanded')
   }
 
   render () {
@@ -175,10 +181,10 @@ class MapSearchBar extends React.Component {
 
     return (
       <div className="map-search-panel">
-        <Button icon size="tiny" className="search-button" onClick={this.handleClick}>
+        <Button icon size="tiny" className="search-button" onClick={this.handleClick} ref="searchButton">
           <Icon name="search" className="search-icon" />
         </Button>
-        <form onSubmit={this.handleSubmit} className="inputContainer">
+        <form ref="searchBar" onSubmit={this.handleSubmit} className="inputContainer">
           <Autosuggest
             ref={(ref) => { this.autosuggestBar = ref }}
             suggestions={this.state.suggestions}


### PR DESCRIPTION
Also geocoder is moved to upper left corner. Not sure if suggestions box should remain as is since it is now covering the zoom controls when opened. However, my thought process is that when the suggestions box is opened, the user wouldn't need the zoom controls anyway. Once the user clicks a place the suggestions container is closed and the zoom controls can be used again. 
In reference to issue #39 