### PR TITLE
Add route selection modes.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5794,9 +5794,14 @@
       }
     },
     "leaflet": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.1.0.tgz",
-      "integrity": "sha512-JK2bT5tZnLQlNuLa8pjOvUC/c/t4MfXBPZyrNK3C1BBxfX1rMHxFC2DvVCNd8esRjDtEddnwSTlv54sC5gvtMQ=="
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.0.3.tgz",
+      "integrity": "sha1-H0AbmLRcgZITTGyNaWhiU4BQB8g="
+    },
+    "leaflet-editable": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/leaflet-editable/-/leaflet-editable-1.0.0.tgz",
+      "integrity": "sha1-G+/O/b7OVQ2otDKp6EE6bB1wF/Y="
     },
     "leaflet-extra-markers": {
       "version": "1.0.6",
@@ -8303,12 +8308,12 @@
       }
     },
     "react-leaflet": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/react-leaflet/-/react-leaflet-1.4.0.tgz",
-      "integrity": "sha512-d/c+2ajuTEtNkMgO15ZQ6/kiV5EY420XsqNWgbdD3iudP6UZqnXuMdv3oReIlc5XLKHamO6fN+vr/2Xb/L04OQ==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/react-leaflet/-/react-leaflet-1.3.1.tgz",
+      "integrity": "sha512-cnJGgOEtjDQcgvHvUFPjIkyY04F50o9XKPiEnpZM8JIkPxMlUjmb60TbsJ4eDtduKUyXbosInlXqTF8QH0Uisw==",
       "requires": {
-        "babel-runtime": "6.23.0",
         "lodash": "4.17.4",
+        "prop-types": "15.5.10",
         "warning": "3.0.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "dependencies": {
     "@mapbox/polyline": "0.2.0",
     "big-integer": "1.6.23",
-    "leaflet": "1.1.0",
+    "leaflet": "1.0.3",
+    "leaflet-editable": "1.0.0",
     "leaflet-extra-markers": "1.0.6",
     "lodash": "4.17.4",
     "moment": "2.18.1",
@@ -14,7 +15,7 @@
     "react-autosuggest": "9.3.1",
     "react-dates": "12.2.3",
     "react-dom": "15.6.1",
-    "react-leaflet": "1.4.0",
+    "react-leaflet": "1.3.1",
     "react-redux": "5.0.5",
     "react-scripts": "1.0.9",
     "redux": "3.7.1",

--- a/src/components/Map/Map.css
+++ b/src/components/Map/Map.css
@@ -14,3 +14,7 @@
 .leaflet-control-attribution a:hover {
   color: #ddd;
 }
+
+.map-bounding-box-disabled {
+  cursor: inherit;
+}

--- a/src/components/Map/index.js
+++ b/src/components/Map/index.js
@@ -50,6 +50,9 @@ export default class Map extends React.Component {
     })
 
     layer.addTo(this.map.leafletElement)
+
+    // Expose map globally for debug
+    window.map = this.map.leafletElement
   }
 
   // When map is dragged/zoomed and lat/lng/zoom are changed, update URL to reflect change

--- a/src/components/Map/index.js
+++ b/src/components/Map/index.js
@@ -2,6 +2,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { Map as Leaflet, ScaleControl } from 'react-leaflet'
+import 'leaflet-editable'
 // import Tangram from 'tangram'
 import { updateURL } from '../../lib/url-state'
 import 'leaflet/dist/leaflet.css'
@@ -72,6 +73,8 @@ export default class Map extends React.Component {
   render () {
     const { className, children, center, zoom, onClick } = this.props
 
+    // The `editable` option is not provided by Leaflet but by Leaflet.Editable.
+    // It is passed to the options object via props.
     return (
       <Leaflet
         className={className}
@@ -80,6 +83,7 @@ export default class Map extends React.Component {
         onClick={onClick}
         onMoveEnd={this.onChange}
         ref={(ref) => { this.map = ref }}
+        editable
       >
         <ScaleControl />
         {children}

--- a/src/components/MapContainer.js
+++ b/src/components/MapContainer.js
@@ -67,6 +67,8 @@ class MapContainer extends React.Component {
     // a bug where clicking a polyline and then adding a marker causes another
     // onClick to fire in the wrong place.
     if (event.originalEvent.target.tagName === 'CANVAS') {
+      if (this.props.mode !== 'ROUTE') return
+
       this.props.addWaypoint(event.latlng)
     }
   }
@@ -176,6 +178,7 @@ class MapContainer extends React.Component {
 
 function mapStateToProps (state) {
   return {
+    mode: state.app.analysisMode,
     config: state.config,
     route: state.route,
     map: state.map

--- a/src/components/MapContainer.js
+++ b/src/components/MapContainer.js
@@ -14,6 +14,7 @@ import { getTilesForBbox, getTileUrlSuffix } from '../lib/tiles'
 import * as mapActionCreators from '../store/actions/map'
 import * as routeActionCreators from '../store/actions/route'
 import { updateURL } from '../lib/url-state'
+import { drawBounds } from '../lib/region-bounds'
 
 class MapContainer extends React.Component {
   static propTypes = {
@@ -32,6 +33,12 @@ class MapContainer extends React.Component {
     this.handleRemoveWaypoint = this.handleRemoveWaypoint.bind(this)
     this.onDragEndWaypoint = this.onDragEndWaypoint.bind(this)
     this.onClickDismissErrors = this.onClickDismissErrors.bind(this)
+  }
+
+  componentDidMount () {
+    if (this.props.bounds) {
+      drawBounds(this.props.bounds)
+    }
   }
 
   componentDidUpdate (prevProps) {
@@ -181,7 +188,8 @@ function mapStateToProps (state) {
     mode: state.app.analysisMode,
     config: state.config,
     route: state.route,
-    map: state.map
+    map: state.map,
+    bounds: state.viewBounds.bounds
   }
 }
 

--- a/src/components/MapContainer.js
+++ b/src/components/MapContainer.js
@@ -118,10 +118,10 @@ class MapContainer extends React.Component {
           tileUrls.push(`${STATIC_TILE_PATH}${getTileUrlSuffix(i)}.json`)
         })
 
-        const promises = tileUrls.map(url => fetch(url).then(res => res.json()))
-        Promise.all(promises).then(results => {
-          console.log(results)
-        })
+        // const promises = tileUrls.map(url => fetch(url).then(res => res.json()))
+        // Promise.all(promises).then(results => {
+        //   console.log(results)
+        // })
 
         return coordinates
       })

--- a/src/components/MapContainer.js
+++ b/src/components/MapContainer.js
@@ -111,11 +111,17 @@ class MapContainer extends React.Component {
 
         // Get tiles (experimental)
         const STATIC_TILE_PATH = 'https://s3.amazonaws.com/speed-extracts/week0_2017/'
-        tiles.forEach(i => {
-          console.log(i)
-          console.log(`${STATIC_TILE_PATH}${getTileUrlSuffix(i)}.json`)
+        // For now, reject tiles at level 2
+        const downloadTiles = reject(tiles, (i) => i[0] === 2)
+        const tileUrls = []
+        downloadTiles.forEach(i => {
+          tileUrls.push(`${STATIC_TILE_PATH}${getTileUrlSuffix(i)}.json`)
         })
-        // Promise.all()
+
+        const promises = tileUrls.map(url => fetch(url).then(res => res.json()))
+        Promise.all(promises).then(results => {
+          console.log(results)
+        })
 
         return coordinates
       })

--- a/src/components/MapContainer.js
+++ b/src/components/MapContainer.js
@@ -8,8 +8,9 @@ import MapSearchBar from './MapSearchBar'
 import RouteMarkers from './Map/RouteMarkers'
 import RouteLine from './Map/RouteLine'
 import RouteError from './Map/RouteError'
-import { getRoute, valhallaResponseToPolylineCoordinates } from '../lib/valhalla'
+import { getRoute, getTraceAttributes, valhallaResponseToPolylineCoordinates } from '../lib/valhalla'
 import { getNewWaypointPosition } from '../lib/routing'
+import { getTilesForBbox } from '../lib/tiles'
 import * as mapActionCreators from '../store/actions/map'
 import * as routeActionCreators from '../store/actions/route'
 import { updateURL } from '../lib/url-state'
@@ -103,6 +104,21 @@ class MapContainer extends React.Component {
       .then(response => {
         const coordinates = valhallaResponseToPolylineCoordinates(response)
         this.props.setRoute(coordinates)
+
+        // Get bounding box for OSMLR tiles
+        const bounds = response.trip.summary
+        const tiles = getTilesForBbox(bounds.min_lon, bounds.min_lat, bounds.max_lon, bounds.max_lat)
+        console.log('tiles', tiles)
+        Promise.all()
+
+        return coordinates
+      })
+      .then(coordinates => {
+        // Experimental.
+        return getTraceAttributes(host, coordinates)
+      })
+      .then(response => {
+        console.log(response)
       })
       .catch(error => {
         let message

--- a/src/components/MapContainer.js
+++ b/src/components/MapContainer.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { bindActionCreators } from 'redux'
 import { connect } from 'react-redux'
 import PropTypes from 'prop-types'
-import { isEqual } from 'lodash'
+import { isEqual, reject } from 'lodash'
 import Map from './Map'
 import MapSearchBar from './MapSearchBar'
 import RouteMarkers from './Map/RouteMarkers'
@@ -111,11 +111,17 @@ class MapContainer extends React.Component {
 
         // Get tiles (experimental)
         const STATIC_TILE_PATH = 'https://s3.amazonaws.com/speed-extracts/week0_2017/'
-        tiles.forEach(i => {
-          console.log(i)
-          console.log(`${STATIC_TILE_PATH}${getTileUrlSuffix(i)}.json`)
+        // For now, reject tiles at level 2
+        const downloadTiles = reject(tiles, (i) => i[0] === 2)
+        const tileUrls = []
+        downloadTiles.forEach(i => {
+          tileUrls.push(`${STATIC_TILE_PATH}${getTileUrlSuffix(i)}.json`)
         })
-        // Promise.all()
+
+        const promises = tileUrls.map(url => fetch(url).then(res => res.json()))
+        Promise.all(promises).then(results => {
+          console.log(results)
+        })
 
         return coordinates
       })

--- a/src/components/MapContainer.js
+++ b/src/components/MapContainer.js
@@ -111,17 +111,11 @@ class MapContainer extends React.Component {
 
         // Get tiles (experimental)
         const STATIC_TILE_PATH = 'https://s3.amazonaws.com/speed-extracts/week0_2017/'
-        // For now, reject tiles at level 2
-        const downloadTiles = reject(tiles, (i) => i[0] === 2)
-        const tileUrls = []
-        downloadTiles.forEach(i => {
-          tileUrls.push(`${STATIC_TILE_PATH}${getTileUrlSuffix(i)}.json`)
+        tiles.forEach(i => {
+          console.log(i)
+          console.log(`${STATIC_TILE_PATH}${getTileUrlSuffix(i)}.json`)
         })
-
-        const promises = tileUrls.map(url => fetch(url).then(res => res.json()))
-        Promise.all(promises).then(results => {
-          console.log(results)
-        })
+        // Promise.all()
 
         return coordinates
       })

--- a/src/components/MapContainer.js
+++ b/src/components/MapContainer.js
@@ -10,7 +10,7 @@ import RouteLine from './Map/RouteLine'
 import RouteError from './Map/RouteError'
 import { getRoute, getTraceAttributes, valhallaResponseToPolylineCoordinates } from '../lib/valhalla'
 import { getNewWaypointPosition } from '../lib/routing'
-import { getTilesForBbox } from '../lib/tiles'
+import { getTilesForBbox, getTileUrlSuffix } from '../lib/tiles'
 import * as mapActionCreators from '../store/actions/map'
 import * as routeActionCreators from '../store/actions/route'
 import { updateURL } from '../lib/url-state'
@@ -108,8 +108,14 @@ class MapContainer extends React.Component {
         // Get bounding box for OSMLR tiles
         const bounds = response.trip.summary
         const tiles = getTilesForBbox(bounds.min_lon, bounds.min_lat, bounds.max_lon, bounds.max_lat)
-        console.log('tiles', tiles)
-        Promise.all()
+
+        // Get tiles (experimental)
+        const STATIC_TILE_PATH = 'https://s3.amazonaws.com/speed-extracts/week0_2017/'
+        tiles.forEach(i => {
+          console.log(i)
+          console.log(`${STATIC_TILE_PATH}${getTileUrlSuffix(i)}.json`)
+        })
+        // Promise.all()
 
         return coordinates
       })

--- a/src/components/Sidebar/ModeSelect/index.js
+++ b/src/components/Sidebar/ModeSelect/index.js
@@ -1,8 +1,15 @@
 import React from 'react'
+import PropTypes from 'prop-types'
+import { connect } from 'react-redux'
 import { Segment, Header, Button } from 'semantic-ui-react'
 import { onClickDrawRectangle } from '../../../lib/region-bounds'
+import * as app from '../../../store/reducers/app'
 
-export default class ModeSelect extends React.PureComponent {
+class ModeSelect extends React.PureComponent {
+  static propTypes = {
+    dispatch: PropTypes.func.isRequired
+  }
+
   constructor (props) {
     super(props)
 
@@ -12,10 +19,11 @@ export default class ModeSelect extends React.PureComponent {
 
   onClickRegion (event) {
     onClickDrawRectangle()
+    this.props.dispatch(app.setRegionAnalysisMode())
   }
 
   onClickRoute (event) {
-    onClickRoute()
+    this.props.dispatch(app.setRouteAnalysisMode())
   }
 
   render () {
@@ -34,3 +42,5 @@ export default class ModeSelect extends React.PureComponent {
     )
   }
 }
+
+export default connect()(ModeSelect)

--- a/src/components/Sidebar/ModeSelect/index.js
+++ b/src/components/Sidebar/ModeSelect/index.js
@@ -38,18 +38,18 @@ class ModeSelect extends React.PureComponent {
   render () {
     return (
       <Segment>
-        <Header as="h3">Select mode</Header>
+        <Header as="h3">Analysis mode</Header>
         <Button.Group fluid>
           <Button
             icon="crop"
-            content="Analyze region"
+            content="Region"
             color="blue"
             onClick={this.onClickRegion}
             basic={!(this.props.activeMode === 'REGION')}
           />
           <Button
             icon="car"
-            content="Analyze route"
+            content="Route"
             color="blue"
             onClick={this.onClickRoute}
             basic={!(this.props.activeMode === 'ROUTE')}
@@ -57,7 +57,7 @@ class ModeSelect extends React.PureComponent {
         </Button.Group>
         <Button
           icon="remove"
-          content="Clear analysis area"
+          content="Clear analysis"
           color="grey"
           onClick={this.onClickClearAnalysis}
           fluid

--- a/src/components/Sidebar/ModeSelect/index.js
+++ b/src/components/Sidebar/ModeSelect/index.js
@@ -3,8 +3,8 @@ import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import { Segment, Header, Button } from 'semantic-ui-react'
 import { startDrawingBounds } from '../../../lib/region-bounds'
-import * as app from '../../../store/reducers/app'
-import { setBounds } from '../../../store/reducers/viewBounds'
+import * as app from '../../../store/actions/app'
+import { setBounds } from '../../../store/actions/viewBounds'
 
 class ModeSelect extends React.PureComponent {
   static propTypes = {

--- a/src/components/Sidebar/ModeSelect/index.js
+++ b/src/components/Sidebar/ModeSelect/index.js
@@ -38,6 +38,9 @@ class ModeSelect extends React.PureComponent {
             onClick={this.onClickRoute}
           />
         </Button.Group>
+        <Button content="Clear analysis area" color="gray"
+          onClick={this.onClickRoute} fluid basic style={{ marginTop: '0.5em' }}
+        />
       </Segment>
     )
   }

--- a/src/components/Sidebar/ModeSelect/index.js
+++ b/src/components/Sidebar/ModeSelect/index.js
@@ -5,6 +5,7 @@ import { Segment, Header, Button } from 'semantic-ui-react'
 import { startDrawingBounds } from '../../../lib/region-bounds'
 import * as app from '../../../store/actions/app'
 import { setBounds } from '../../../store/actions/viewBounds'
+import { resetAnalysis } from '../../../store/actions/reset'
 
 class ModeSelect extends React.PureComponent {
   static propTypes = {
@@ -42,7 +43,7 @@ class ModeSelect extends React.PureComponent {
   }
 
   onClickClearAnalysis (event) {
-    this.props.dispatch(app.clearAnalysisMode())
+    this.props.dispatch(resetAnalysis())
   }
 
   render () {

--- a/src/components/Sidebar/ModeSelect/index.js
+++ b/src/components/Sidebar/ModeSelect/index.js
@@ -4,7 +4,6 @@ import { connect } from 'react-redux'
 import { Segment, Header, Button } from 'semantic-ui-react'
 import { startDrawingBounds } from '../../../lib/region-bounds'
 import * as app from '../../../store/actions/app'
-import { setBounds } from '../../../store/actions/viewBounds'
 import { resetAnalysis } from '../../../store/actions/reset'
 
 class ModeSelect extends React.PureComponent {
@@ -18,27 +17,16 @@ class ModeSelect extends React.PureComponent {
     this.onClickRegion = this.onClickRegion.bind(this)
     this.onClickRoute = this.onClickRoute.bind(this)
     this.onClickClearAnalysis = this.onClickClearAnalysis.bind(this)
-    this.handleBounds = this.handleBounds.bind(this)
-  }
-
-  /**
-   * @param {L.LatLngBounds}
-   */
-  handleBounds (latLngBounds) {
-    const north = latLngBounds.getNorth()
-    const south = latLngBounds.getSouth()
-    const east = latLngBounds.getEast()
-    const west = latLngBounds.getWest()
-
-    this.props.dispatch(setBounds({ north, south, east, west }))
   }
 
   onClickRegion (event) {
-    startDrawingBounds(this.handleBounds)
+    startDrawingBounds()
+    this.props.dispatch(resetAnalysis())
     this.props.dispatch(app.setRegionAnalysisMode())
   }
 
   onClickRoute (event) {
+    this.props.dispatch(resetAnalysis())
     this.props.dispatch(app.setRouteAnalysisMode())
   }
 

--- a/src/components/Sidebar/ModeSelect/index.js
+++ b/src/components/Sidebar/ModeSelect/index.js
@@ -8,7 +8,8 @@ import { resetAnalysis } from '../../../store/actions/reset'
 
 class ModeSelect extends React.PureComponent {
   static propTypes = {
-    dispatch: PropTypes.func.isRequired
+    dispatch: PropTypes.func.isRequired,
+    activeMode: PropTypes.string
   }
 
   constructor (props) {
@@ -39,19 +40,39 @@ class ModeSelect extends React.PureComponent {
       <Segment>
         <Header as="h3">Select mode</Header>
         <Button.Group fluid>
-          <Button icon="crop" content="Analyze region" color="yellow"
+          <Button
+            icon="crop"
+            content="Analyze region"
+            color="blue"
             onClick={this.onClickRegion}
+            basic={!(this.props.activeMode === 'REGION')}
           />
-          <Button icon="car" content="Analyze route" color="teal"
+          <Button
+            icon="car"
+            content="Analyze route"
+            color="blue"
             onClick={this.onClickRoute}
+            basic={!(this.props.activeMode === 'ROUTE')}
           />
         </Button.Group>
-        <Button icon="remove" content="Clear analysis area" color="grey"
-          onClick={this.onClickClearAnalysis} fluid basic style={{ marginTop: '0.5em' }}
+        <Button
+          icon="remove"
+          content="Clear analysis area"
+          color="grey"
+          onClick={this.onClickClearAnalysis}
+          fluid
+          basic
+          style={{ marginTop: '0.5em' }}
         />
       </Segment>
     )
   }
 }
 
-export default connect()(ModeSelect)
+function mapStateToProps (state) {
+  return {
+    activeMode: state.app.analysisMode
+  }
+}
+
+export default connect(mapStateToProps)(ModeSelect)

--- a/src/components/Sidebar/ModeSelect/index.js
+++ b/src/components/Sidebar/ModeSelect/index.js
@@ -1,0 +1,36 @@
+import React from 'react'
+import { Segment, Header, Button } from 'semantic-ui-react'
+import { onClickDrawRectangle } from '../../../lib/region-bounds'
+
+export default class ModeSelect extends React.PureComponent {
+  constructor (props) {
+    super(props)
+
+    this.onClickRegion = this.onClickRegion.bind(this)
+    this.onClickRoute = this.onClickRoute.bind(this)
+  }
+
+  onClickRegion (event) {
+    onClickDrawRectangle()
+  }
+
+  onClickRoute (event) {
+    onClickRoute()
+  }
+
+  render () {
+    return (
+      <Segment>
+        <Header as="h3">Select mode</Header>
+        <Button.Group fluid>
+          <Button icon="crop" content="Analyze region" color="yellow"
+            onClick={this.onClickRegion}
+          />
+          <Button icon="crop" content="Analyze route" color="teal"
+            onClick={this.onClickRoute}
+          />
+        </Button.Group>
+      </Segment>
+    )
+  }
+}

--- a/src/components/Sidebar/ModeSelect/index.js
+++ b/src/components/Sidebar/ModeSelect/index.js
@@ -21,9 +21,9 @@ class ModeSelect extends React.PureComponent {
   }
 
   onClickRegion (event) {
-    startDrawingBounds()
     this.props.dispatch(resetAnalysis())
     this.props.dispatch(app.setRegionAnalysisMode())
+    startDrawingBounds()
   }
 
   onClickRoute (event) {

--- a/src/components/Sidebar/ModeSelect/index.js
+++ b/src/components/Sidebar/ModeSelect/index.js
@@ -16,6 +16,7 @@ class ModeSelect extends React.PureComponent {
 
     this.onClickRegion = this.onClickRegion.bind(this)
     this.onClickRoute = this.onClickRoute.bind(this)
+    this.onClickClearAnalysis = this.onClickClearAnalysis.bind(this)
     this.handleBounds = this.handleBounds.bind(this)
   }
 
@@ -40,6 +41,10 @@ class ModeSelect extends React.PureComponent {
     this.props.dispatch(app.setRouteAnalysisMode())
   }
 
+  onClickClearAnalysis (event) {
+    this.props.dispatch(app.clearAnalysisMode())
+  }
+
   render () {
     return (
       <Segment>
@@ -48,12 +53,12 @@ class ModeSelect extends React.PureComponent {
           <Button icon="crop" content="Analyze region" color="yellow"
             onClick={this.onClickRegion}
           />
-          <Button icon="crop" content="Analyze route" color="teal"
+          <Button icon="car" content="Analyze route" color="teal"
             onClick={this.onClickRoute}
           />
         </Button.Group>
-        <Button content="Clear analysis area" color="grey"
-          onClick={this.onClickRoute} fluid basic style={{ marginTop: '0.5em' }}
+        <Button icon="remove" content="Clear analysis area" color="grey"
+          onClick={this.onClickClearAnalysis} fluid basic style={{ marginTop: '0.5em' }}
         />
       </Segment>
     )

--- a/src/components/Sidebar/ModeSelect/index.js
+++ b/src/components/Sidebar/ModeSelect/index.js
@@ -2,8 +2,9 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import { Segment, Header, Button } from 'semantic-ui-react'
-import { onClickDrawRectangle } from '../../../lib/region-bounds'
+import { startDrawingBounds } from '../../../lib/region-bounds'
 import * as app from '../../../store/reducers/app'
+import { setBounds } from '../../../store/reducers/viewBounds'
 
 class ModeSelect extends React.PureComponent {
   static propTypes = {
@@ -15,10 +16,23 @@ class ModeSelect extends React.PureComponent {
 
     this.onClickRegion = this.onClickRegion.bind(this)
     this.onClickRoute = this.onClickRoute.bind(this)
+    this.handleBounds = this.handleBounds.bind(this)
+  }
+
+  /**
+   * @param {L.LatLngBounds}
+   */
+  handleBounds (latLngBounds) {
+    const north = latLngBounds.getNorth()
+    const south = latLngBounds.getSouth()
+    const east = latLngBounds.getEast()
+    const west = latLngBounds.getWest()
+
+    this.props.dispatch(setBounds({ north, south, east, west }))
   }
 
   onClickRegion (event) {
-    onClickDrawRectangle()
+    startDrawingBounds(this.handleBounds)
     this.props.dispatch(app.setRegionAnalysisMode())
   }
 
@@ -38,7 +52,7 @@ class ModeSelect extends React.PureComponent {
             onClick={this.onClickRoute}
           />
         </Button.Group>
-        <Button content="Clear analysis area" color="gray"
+        <Button content="Clear analysis area" color="grey"
           onClick={this.onClickRoute} fluid basic style={{ marginTop: '0.5em' }}
         />
       </Segment>

--- a/src/components/Sidebar/index.js
+++ b/src/components/Sidebar/index.js
@@ -3,6 +3,7 @@ import { connect } from 'react-redux'
 import { Segment, Header, Accordion, Checkbox, Button, Message } from 'semantic-ui-react'
 import DatePickerContainer from '../DatePickerContainer'
 import ErrorMessage from './ErrorMessage'
+import { onClickDrawRectangle } from '../../lib/region-bounds'
 import './Sidebar.css'
 
 const panels = [
@@ -31,6 +32,12 @@ const Sidebar = (props) => {
   return (
     <div className={'Sidebar ' + props.className}>
       {errors}
+      <Segment>
+        <Header as="h3">Select mode</Header>
+        <Button icon="crop" content="Select region" color="yellow" fluid
+          onClick={onClickDrawRectangle}
+         />
+      </Segment>
       <Segment>
         <Header as="h3">Section header</Header>
         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>

--- a/src/components/Sidebar/index.js
+++ b/src/components/Sidebar/index.js
@@ -3,7 +3,7 @@ import { connect } from 'react-redux'
 import { Segment, Header, Accordion, Checkbox, Button, Message } from 'semantic-ui-react'
 import DatePickerContainer from '../DatePickerContainer'
 import ErrorMessage from './ErrorMessage'
-import { onClickDrawRectangle } from '../../lib/region-bounds'
+import ModeSelect from './ModeSelect'
 import './Sidebar.css'
 
 const panels = [
@@ -32,17 +32,7 @@ const Sidebar = (props) => {
   return (
     <div className={'Sidebar ' + props.className}>
       {errors}
-      <Segment>
-        <Header as="h3">Select mode</Header>
-        <Button.Group fluid>
-          <Button icon="crop" content="Analyze region" color="yellow"
-            onClick={onClickDrawRectangle}
-          />
-          <Button icon="crop" content="Analyze route" color="teal"
-            onClick={onClickDrawRectangle}
-          />
-        </Button.Group>
-      </Segment>
+      <ModeSelect />
       <Segment>
         <Header as="h3">Section header</Header>
         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>

--- a/src/components/Sidebar/index.js
+++ b/src/components/Sidebar/index.js
@@ -34,15 +34,15 @@ const Sidebar = (props) => {
       {errors}
       <ModeSelect />
       <Segment>
+        <DatePickerContainer className="date-picker" />
+      </Segment>
+      <Segment>
         <Header as="h3">Section header</Header>
         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
         <Message>
           <Checkbox toggle label="Toggle" />
         </Message>
         <Accordion panels={panels} styled />
-      </Segment>
-      <Segment>
-        <DatePickerContainer className="date-picker" />
       </Segment>
       <Segment>
         <Header as="h3">Export</Header>

--- a/src/components/Sidebar/index.js
+++ b/src/components/Sidebar/index.js
@@ -34,9 +34,14 @@ const Sidebar = (props) => {
       {errors}
       <Segment>
         <Header as="h3">Select mode</Header>
-        <Button icon="crop" content="Select region" color="yellow" fluid
-          onClick={onClickDrawRectangle}
-         />
+        <Button.Group fluid>
+          <Button icon="crop" content="Analyze region" color="yellow"
+            onClick={onClickDrawRectangle}
+          />
+          <Button icon="crop" content="Analyze route" color="teal"
+            onClick={onClickDrawRectangle}
+          />
+        </Button.Group>
       </Segment>
       <Segment>
         <Header as="h3">Section header</Header>

--- a/src/init.js
+++ b/src/init.js
@@ -4,9 +4,9 @@ import store from './store'
 import { recenterMap, setLocation } from './store/actions/map'
 import { setDate } from './store/actions/date'
 import { addWaypoint } from './store/actions/route'
+import { setBounds } from './store/actions/viewBounds'
 import { setRegionAnalysisMode, setRouteAnalysisMode } from './store/actions/app'
 import { getQueryStringObject, updateURL } from './lib/url-state'
-import { drawBounds } from './lib/region-bounds'
 
 // Initialize application based on url query string params
 export function initApp (queryString = window.location.search) {
@@ -63,8 +63,6 @@ function initRoute (value) {
 }
 
 function initBounds (west, south, east, north) {
-  window.setTimeout(() => {
-    drawBounds(west, south, east, north)
-  }, 1000)
+  store.dispatch(setBounds({ north, south, east, west }))
   store.dispatch(setRegionAnalysisMode())
 }

--- a/src/lib/region-bounds.js
+++ b/src/lib/region-bounds.js
@@ -137,6 +137,11 @@ export function drawBounds (west, south, east, north) {
     [south, east]
   ]).addTo(map)
   rect.enableEdit()
+
+  if (!handlersAdded) {
+    addEventListeners()
+    handlersAdded = true
+  }
   bounds.push(rect)
   storeBounds(rect.getBounds())
 }

--- a/src/lib/region-bounds.js
+++ b/src/lib/region-bounds.js
@@ -6,10 +6,17 @@ import { setBounds } from '../store/actions/viewBounds'
 const bounds = []
 let handlersAdded = false
 
-// If anything changes the viewbounds in store, update (or remove) current bounds.
+// Subscribe to changes in state to affect the behavior of Leaflet.Editable.
 store.subscribe(() => {
   const state = store.getState()
+
+  // If bounds are cleared from state, remove current bounds.
   if (!state.viewBounds.bounds) removeAllExistingBounds()
+
+  // If select mode has changed, stop any existing drawing interaction.
+  if (!state.app.analysisMode !== 'REGION' && typeof map !== 'undefined' && map.editTools) {
+    map.editTools.stopDrawing()
+  }
 })
 
 /**

--- a/src/lib/region-bounds.js
+++ b/src/lib/region-bounds.js
@@ -15,19 +15,48 @@ function removeExistingBounds (index = 0) {
   }
 }
 
-export function onClickDrawRectangle (event) {
+/**
+ * Sets the appearance and interactivity of a boundary to be in disabled state.
+ *
+ * @param {LatLngBounds} bound - boundary object to change.
+ */
+function setBoundToDisabledAppearance (bound) {
+  bound.setStyle({
+    weight: 1,
+    color: '#aaa',
+    fill: '#aaa',
+    fillOpacity: 0,
+    dashArray: [5, 3]
+  })
+  bound._path.classList.add('map-bounding-box-disabled')
+  bound.editor.disable()
+}
+
+/**
+ * Handler function for drawing new viewport bounds.
+ *
+ * @param {Object} event - from onClick handler
+ * @param {Function} callback - optional. Callback function to call after the
+ *          bounds has finished drawing.
+ */
+export function onClickDrawRectangle (event, callback) {
   if (!handlersAdded) {
     map.on('editable:drawing:commit', function (event) {
       // The newly created rectangle is stored at `event.layer`
-      const theBounds = event.layer.getBounds()
       bounds.push(event.layer)
-      console.log(theBounds.getWest(), theBounds.getSouth(), theBounds.getEast(), theBounds.getNorth())
 
       // Remove previous bounds after the new one has been drawn.
       if (bounds.length > 1) {
         removeExistingBounds(0)
       }
+
+      // Get the bounds object of the layer and return it in the callback function.
+      if (typeof callback === 'function') {
+        callback(event.layer.getBounds())
+      }
     })
+
+    // TODO: Handle canceling.
 
     handlersAdded = true
   }
@@ -35,15 +64,7 @@ export function onClickDrawRectangle (event) {
   // Remove the handles on existing bounds, but don't remove yet. It remains
   // as a "ghost" so that it can be referenced when new bounds are drawn over it.
   if (bounds.length) {
-    bounds.forEach(bound => {
-      bound.setStyle({
-        weight: 1,
-        color: '#aaa',
-        fill: '#aaa'
-      })
-      bound._path.classList.add('map-bounding-box-disabled')
-      bound.editor.disable()
-    })
+    bounds.forEach(setBoundToDisabledAppearance)
   }
 
   map.editTools.startRectangle()

--- a/src/lib/region-bounds.js
+++ b/src/lib/region-bounds.js
@@ -1,4 +1,4 @@
-/* global map */
+/* global map, L */
 import store from '../store'
 import { setBounds } from '../store/actions/viewBounds'
 import { updateURL } from './url-state'
@@ -71,18 +71,7 @@ function setBoundToDisabledAppearance (bound) {
   bound.editor.disable()
 }
 
-function onDrawingFinished (event) {
-  // The newly created rectangle is stored at `event.layer`
-  bounds.push(event.layer)
-
-  // Remove previous bounds after the new one has been drawn.
-  if (bounds.length > 1) {
-    removeExistingBounds(0)
-  }
-}
-
-function onDrawingEdited (event) {
-  const bounds = event.layer.getBounds()
+function storeBounds (bounds) {
   const precision = 6
   const north = bounds.getNorth().toFixed(precision)
   const south = bounds.getSouth().toFixed(precision)
@@ -99,6 +88,20 @@ function onDrawingEdited (event) {
     re: east,
     rw: west
   })
+}
+
+function onDrawingFinished (event) {
+  // The newly created rectangle is stored at `event.layer`
+  bounds.push(event.layer)
+
+  // Remove previous bounds after the new one has been drawn.
+  if (bounds.length > 1) {
+    removeExistingBounds(0)
+  }
+}
+
+function onDrawingEdited (event) {
+  storeBounds(event.layer.getBounds())
 }
 
 function addEventListeners () {
@@ -126,4 +129,14 @@ export function startDrawingBounds () {
   }
 
   map.editTools.startRectangle()
+}
+
+export function drawBounds (west, south, east, north) {
+  const rect = L.rectangle([
+    [north, west],
+    [south, east]
+  ]).addTo(map)
+  rect.enableEdit()
+  bounds.push(rect)
+  storeBounds(rect.getBounds())
 }

--- a/src/lib/region-bounds.js
+++ b/src/lib/region-bounds.js
@@ -1,0 +1,50 @@
+/* global map */
+
+// Store for existing bounds.
+const bounds = []
+let handlersAdded = false
+
+// Removes an existing bounds.
+function removeExistingBounds (index = 0) {
+  if (bounds[index] && bounds[index].remove) {
+    // Manual cleanup on Leaflet
+    bounds[index].remove()
+
+    // Remove from memory
+    bounds.splice(index, 1)
+  }
+}
+
+export function onClickDrawRectangle (event) {
+  if (!handlersAdded) {
+    map.on('editable:drawing:commit', function (event) {
+      // The newly created rectangle is stored at `event.layer`
+      const theBounds = event.layer.getBounds()
+      bounds.push(event.layer)
+      console.log(theBounds.getWest(), theBounds.getSouth(), theBounds.getEast(), theBounds.getNorth())
+
+      // Remove previous bounds after the new one has been drawn.
+      if (bounds.length > 1) {
+        removeExistingBounds(0)
+      }
+    })
+
+    handlersAdded = true
+  }
+
+  // Remove the handles on existing bounds, but don't remove yet. It remains
+  // as a "ghost" so that it can be referenced when new bounds are drawn over it.
+  if (bounds.length) {
+    bounds.forEach(bound => {
+      bound.setStyle({
+        weight: 1,
+        color: '#aaa',
+        fill: '#aaa'
+      })
+      bound._path.classList.add('map-bounding-box-disabled')
+      bound.editor.disable()
+    })
+  }
+
+  map.editTools.startRectangle()
+}

--- a/src/lib/region-bounds.js
+++ b/src/lib/region-bounds.js
@@ -1,6 +1,7 @@
 /* global map */
 import store from '../store'
 import { setBounds } from '../store/actions/viewBounds'
+import { updateURL } from './url-state'
 
 // Store for existing bounds.
 const bounds = []
@@ -59,18 +60,6 @@ function setBoundToDisabledAppearance (bound) {
   bound.editor.disable()
 }
 
-/**
- * @param {L.LatLngBounds}
- */
-function storeBounds (latLngBounds) {
-  const north = latLngBounds.getNorth()
-  const south = latLngBounds.getSouth()
-  const east = latLngBounds.getEast()
-  const west = latLngBounds.getWest()
-
-  store.dispatch(setBounds({ north, south, east, west }))
-}
-
 function onDrawingFinished (event) {
   // The newly created rectangle is stored at `event.layer`
   bounds.push(event.layer)
@@ -82,8 +71,23 @@ function onDrawingFinished (event) {
 }
 
 function onDrawingEdited (event) {
-  // Get the bounds object of the layer and store it.
-  storeBounds(event.layer.getBounds())
+  const bounds = event.layer.getBounds()
+  const precision = 6
+  const north = bounds.getNorth().toFixed(precision)
+  const south = bounds.getSouth().toFixed(precision)
+  const east = bounds.getEast().toFixed(precision)
+  const west = bounds.getWest().toFixed(precision)
+
+  // Store it.
+  store.dispatch(setBounds({ north, south, east, west }))
+
+  // Update URL
+  updateURL({
+    rn: north,
+    rs: south,
+    re: east,
+    rw: west
+  })
 }
 
 function addEventListeners () {

--- a/src/lib/region-bounds.js
+++ b/src/lib/region-bounds.js
@@ -4,7 +4,12 @@
 const bounds = []
 let handlersAdded = false
 
-// Removes an existing bounds.
+/**
+ * Removes an existing bounds.
+ *
+ * @param {Number} index - remove the bounds at this index in the cache.
+ *          Defaults to the earliest bounds (at index 0).
+ */
 function removeExistingBounds (index = 0) {
   if (bounds[index] && bounds[index].remove) {
     // Manual cleanup on Leaflet
@@ -33,13 +38,13 @@ function setBoundToDisabledAppearance (bound) {
 }
 
 /**
- * Handler function for drawing new viewport bounds.
+ * Function for drawing new viewport bounds.
  *
  * @param {Object} event - from onClick handler
  * @param {Function} callback - optional. Callback function to call after the
  *          bounds has finished drawing.
  */
-export function onClickDrawRectangle (event, callback) {
+export function startDrawingBounds (callback) {
   if (!handlersAdded) {
     map.on('editable:drawing:commit', function (event) {
       // The newly created rectangle is stored at `event.layer`

--- a/src/lib/region-bounds.js
+++ b/src/lib/region-bounds.js
@@ -15,10 +15,19 @@ store.subscribe(() => {
   if (!state.viewBounds.bounds) removeAllExistingBounds()
 
   // If select mode has changed, stop any existing drawing interaction.
-  if (!state.app.analysisMode !== 'REGION' && typeof map !== 'undefined' && map.editTools) {
+  if (state.app.analysisMode !== 'REGION' && typeof map !== 'undefined' && map.editTools) {
     map.editTools.stopDrawing()
   }
 })
+
+function removeBoundsFromURL () {
+  updateURL({
+    rn: null,
+    rs: null,
+    re: null,
+    rw: null
+  })
+}
 
 /**
  * Removes an existing bounds.
@@ -41,6 +50,8 @@ function removeAllExistingBounds () {
     bounds[0].remove()
     bounds.shift()
   }
+
+  removeBoundsFromURL()
 }
 
 /**

--- a/src/lib/region-bounds.js
+++ b/src/lib/region-bounds.js
@@ -131,7 +131,7 @@ export function startDrawingBounds () {
   map.editTools.startRectangle()
 }
 
-export function drawBounds (west, south, east, north) {
+export function drawBounds ({ west, south, east, north }) {
   const rect = L.rectangle([
     [north, west],
     [south, east]

--- a/src/lib/tiles.js
+++ b/src/lib/tiles.js
@@ -74,10 +74,41 @@ export function getTilesForBufferedBbox (left, bottom, right, top, buffer = 0.1)
  *
  * @todo Handle improper tile levels or ids.
  * @param {Number} level - tile level (0-2).
- * @param {Number} id - tile id.
+ * @param {Number} tileId - tile index.
+ * - or -
+ * @param {Array} tuple - an array of two values: [ level, tileId ]
+ *          See the return value for getTilesForBbox()
+ * - or -
+ * @param {Object} parsedSegmentId - an object of shape { level, tile, segment }
+ *
+ * @todo standardize on one form?!
+ *
  * @returns {string} urlSuffix - a string for the directory/file.
  */
-export function getTileUrlSuffix (level, id) {
+export function getTileUrlSuffix (arg1, arg2) {
+  function getTileLevel (arg) {
+    if (Array.isArray(arg)) {
+      return arg[0]
+    } else if (typeof arg === 'object' && arg !== null) {
+      return arg.level
+    } else {
+      return arg
+    }
+  }
+
+  function getTileIndex (arg) {
+    if (Array.isArray(arg)) {
+      return arg[1]
+    } else if (typeof arg === 'object' && arg !== null) {
+      return arg.tile
+    } else {
+      return arg
+    }
+  }
+
+  const level = getTileLevel(arg1)
+  const id = getTileIndex(arg2 || arg1)
+
   // Get the right tileset definition for the level we want
   const tileSet = filter(VALHALLA_TILES, { level })[0]
 
@@ -99,7 +130,7 @@ export function getTileUrlSuffix (level, id) {
     suffix = suffix.substr(3)
   }
 
-  return '/' + level + '/' + temp.join('/')
+  return level + '/' + temp.join('/')
 }
 
 const LEVEL_BITS = 3

--- a/src/lib/tiles.js
+++ b/src/lib/tiles.js
@@ -15,10 +15,10 @@ const VALHALLA_TILES = [
  * intersect the bounding box, where the first item in the tuple is the tile
  * level and the second item in the tuple is the tile's index
  *
- * @param {Number} left - western longitude
- * @param {Number} bottom - southern latitude
- * @param {Number} right - eastern longitude
- * @param {Number} top - northern latitude
+ * @param {Number} left - western (minimum) longitude
+ * @param {Number} bottom - southern (minimum) latitude
+ * @param {Number} right - eastern (maximum) longitude
+ * @param {Number} top - northern (maximum) latitude
  * @returns {Array} - of OSMLR tuples [tile level, tile index]
  */
 export function getTilesForBbox (left, bottom, right, top) {

--- a/src/lib/tiles.test.js
+++ b/src/lib/tiles.test.js
@@ -38,12 +38,44 @@ it('creates a directory/file path from a tile level and id', () => {
   const result5 = getTileUrlSuffix(0, 79)
   const result6 = getTileUrlSuffix(0, 4001)
 
-  expect(result1).toEqual('/2/001/036/752')
-  expect(result2).toEqual('/2/000/000/042')
-  expect(result3).toEqual('/1/000/054')
-  expect(result4).toEqual('/1/064/001')
-  expect(result5).toEqual('/0/000/079')
-  expect(result6).toEqual('/0/004/001')
+  expect(result1).toEqual('2/001/036/752')
+  expect(result2).toEqual('2/000/000/042')
+  expect(result3).toEqual('1/000/054')
+  expect(result4).toEqual('1/064/001')
+  expect(result5).toEqual('0/000/079')
+  expect(result6).toEqual('0/004/001')
+})
+
+it('creates a directory/file path from a tile level and id tuple', () => {
+  const result1 = getTileUrlSuffix([2, 1036752])
+  const result2 = getTileUrlSuffix([2, 42])
+  const result3 = getTileUrlSuffix([1, 54])
+  const result4 = getTileUrlSuffix([1, 64001])
+  const result5 = getTileUrlSuffix([0, 79])
+  const result6 = getTileUrlSuffix([0, 4001])
+
+  expect(result1).toEqual('2/001/036/752')
+  expect(result2).toEqual('2/000/000/042')
+  expect(result3).toEqual('1/000/054')
+  expect(result4).toEqual('1/064/001')
+  expect(result5).toEqual('0/000/079')
+  expect(result6).toEqual('0/004/001')
+})
+
+it('creates a directory/file path from a tile level and id objects', () => {
+  const result1 = getTileUrlSuffix({ level: 2, tile: 1036752 })
+  const result2 = getTileUrlSuffix({ level: 2, tile: 42 })
+  const result3 = getTileUrlSuffix({ level: 1, tile: 54 })
+  const result4 = getTileUrlSuffix({ level: 1, tile: 64001 })
+  const result5 = getTileUrlSuffix({ level: 0, tile: 79 })
+  const result6 = getTileUrlSuffix({ level: 0, tile: 4001 })
+
+  expect(result1).toEqual('2/001/036/752')
+  expect(result2).toEqual('2/000/000/042')
+  expect(result3).toEqual('1/000/054')
+  expect(result4).toEqual('1/064/001')
+  expect(result5).toEqual('0/000/079')
+  expect(result6).toEqual('0/004/001')
 })
 
 it('parses a segment id from trace_attributes', () => {

--- a/src/store/actions/app.js
+++ b/src/store/actions/app.js
@@ -1,4 +1,4 @@
-import { SET_ANALYSIS_MODE, CLEAR_ANALYSIS_MODE } from '../actions'
+import { SET_ANALYSIS_MODE, CLEAR_ANALYSIS } from '../actions'
 
 const ROUTE_MODE = 'ROUTE'
 const REGION_MODE = 'REGION'
@@ -19,5 +19,5 @@ export function setRouteAnalysisMode () {
 }
 
 export function clearAnalysisMode () {
-  return { type: CLEAR_ANALYSIS_MODE }
+  return { type: CLEAR_ANALYSIS }
 }

--- a/src/store/actions/app.js
+++ b/src/store/actions/app.js
@@ -1,0 +1,23 @@
+import { SET_ANALYSIS_MODE, CLEAR_ANALYSIS_MODE } from '../actions'
+
+const ROUTE_MODE = 'ROUTE'
+const REGION_MODE = 'REGION'
+
+function setAnalysisMode (mode) {
+  return {
+    type: SET_ANALYSIS_MODE,
+    mode
+  }
+}
+
+export function setRegionAnalysisMode () {
+  return setAnalysisMode(REGION_MODE)
+}
+
+export function setRouteAnalysisMode () {
+  return setAnalysisMode(ROUTE_MODE)
+}
+
+export function clearAnalysisMode () {
+  return { type: CLEAR_ANALYSIS_MODE }
+}

--- a/src/store/actions/index.js
+++ b/src/store/actions/index.js
@@ -1,3 +1,7 @@
+/* app */
+export const SET_ANALYSIS_MODE = 'SET_ANALYSIS_MODE'
+export const CLEAR_ANALYSIS_MODE = 'CLEAR_ANALYSIS_MODE'
+
 /* date */
 export const SET_DATE = 'SET_DATE'
 
@@ -18,4 +22,6 @@ export const INSERT_ROUTE_WAYPOINT = 'INSERT_ROUTE_WAYPOINT'
 export const SET_ROUTE = 'SET_ROUTE'
 export const SET_ROUTE_ERROR = 'SET_ROUTE_ERROR'
 
-export const CLEAR_ANALYSIS_MODE = 'CLEAR_ANALYSIS_MODE'
+/* view bounds */
+export const SET_VIEW_BOUNDS = 'SET_VIEW_BOUNDS'
+export const CLEAR_VIEW_BOUNDS = 'CLEAR_VIEW_BOUNDS'

--- a/src/store/actions/index.js
+++ b/src/store/actions/index.js
@@ -1,6 +1,6 @@
 /* app */
 export const SET_ANALYSIS_MODE = 'SET_ANALYSIS_MODE'
-export const CLEAR_ANALYSIS_MODE = 'CLEAR_ANALYSIS_MODE'
+export const CLEAR_ANALYSIS = 'CLEAR_ANALYSIS'
 
 /* date */
 export const SET_DATE = 'SET_DATE'

--- a/src/store/actions/reset.js
+++ b/src/store/actions/reset.js
@@ -1,0 +1,5 @@
+import { CLEAR_ANALYSIS } from '../actions'
+
+export function resetAnalysis () {
+  return { type: CLEAR_ANALYSIS }
+}

--- a/src/store/actions/route.js
+++ b/src/store/actions/route.js
@@ -4,8 +4,7 @@ import {
   UPDATE_ROUTE_WAYPOINT,
   INSERT_ROUTE_WAYPOINT,
   SET_ROUTE,
-  SET_ROUTE_ERROR,
-  CLEAR_ANALYSIS_MODE
+  SET_ROUTE_ERROR
 } from '../actions'
 
 export function addWaypoint (waypoint) {
@@ -64,8 +63,4 @@ export function clearRouteError () {
     type: SET_ROUTE_ERROR,
     error: null
   }
-}
-
-export function resetRoute () {
-  return { type: CLEAR_ANALYSIS_MODE }
 }

--- a/src/store/actions/viewBounds.js
+++ b/src/store/actions/viewBounds.js
@@ -1,0 +1,14 @@
+import { SET_VIEW_BOUNDS, CLEAR_VIEW_BOUNDS } from '../actions'
+
+export function setBounds (bounds) {
+  return {
+    type: SET_VIEW_BOUNDS,
+    bounds
+  }
+}
+
+export function clearBounds () {
+  return {
+    type: CLEAR_VIEW_BOUNDS
+  }
+}

--- a/src/store/reducers/app.js
+++ b/src/store/reducers/app.js
@@ -1,17 +1,10 @@
-// Constants
-const ROUTE_MODE = 'ROUTE'
-const REGION_MODE = 'REGION'
+import { SET_ANALYSIS_MODE, CLEAR_ANALYSIS_MODE } from '../actions'
 
-// Actions
-const SET_ANALYSIS_MODE = 'analyst-ui/app/SET_ANALYSIS_MODE'
-const CLEAR_ANALYSIS_MODE = 'analyst-ui/app/CLEAR_ANALYSIS_MODE'
-
-// Reducer
 const initialState = {
   analysisMode: null
 }
 
-export default function reducer (state = initialState, action) {
+const app = (state = initialState, action) => {
   switch (action.type) {
     case SET_ANALYSIS_MODE:
       return {
@@ -28,22 +21,4 @@ export default function reducer (state = initialState, action) {
   }
 }
 
-// Action creators
-function setAnalysisMode (mode) {
-  return {
-    type: SET_ANALYSIS_MODE,
-    mode
-  }
-}
-
-export function setRegionAnalysisMode () {
-  return setAnalysisMode(REGION_MODE)
-}
-
-export function setRouteAnalysisMode () {
-  return setAnalysisMode(ROUTE_MODE)
-}
-
-export function clearAnalysisMode () {
-  return { type: CLEAR_ANALYSIS_MODE }
-}
+export default app

--- a/src/store/reducers/app.js
+++ b/src/store/reducers/app.js
@@ -1,4 +1,4 @@
-import { SET_ANALYSIS_MODE, CLEAR_ANALYSIS_MODE } from '../actions'
+import { SET_ANALYSIS_MODE, CLEAR_ANALYSIS } from '../actions'
 
 const initialState = {
   analysisMode: null
@@ -11,7 +11,7 @@ const app = (state = initialState, action) => {
         ...state,
         analysisMode: action.mode
       }
-    case CLEAR_ANALYSIS_MODE:
+    case CLEAR_ANALYSIS:
       return {
         ...state,
         analysisMode: null

--- a/src/store/reducers/app.js
+++ b/src/store/reducers/app.js
@@ -1,0 +1,49 @@
+// Constants
+const ROUTE_MODE = 'ROUTE'
+const REGION_MODE = 'REGION'
+
+// Actions
+const SET_ANALYSIS_MODE = 'analyst-ui/app/SET_ANALYSIS_MODE'
+const CLEAR_ANALYSIS_MODE = 'analyst-ui/app/CLEAR_ANALYSIS_MODE'
+
+// Reducer
+const initialState = {
+  analysisMode: null
+}
+
+export default function reducer (state = initialState, action) {
+  switch (action.type) {
+    case SET_ANALYSIS_MODE:
+      return {
+        ...state,
+        analysisMode: action.mode
+      }
+    case CLEAR_ANALYSIS_MODE:
+      return {
+        ...state,
+        analysisMode: null
+      }
+    default:
+      return state
+  }
+}
+
+// Action creators
+function setAnalysisMode (mode) {
+  return {
+    type: SET_ANALYSIS_MODE,
+    mode
+  }
+}
+
+export function setRegionAnalysisMode () {
+  return setAnalysisMode(REGION_MODE)
+}
+
+export function setRouteAnalysisMode () {
+  return setAnalysisMode(ROUTE_MODE)
+}
+
+export function clearAnalysisMode () {
+  return { type: CLEAR_ANALYSIS_MODE }
+}

--- a/src/store/reducers/index.js
+++ b/src/store/reducers/index.js
@@ -1,4 +1,5 @@
 import { combineReducers } from 'redux'
+import app from './app'
 import config from './config'
 import date from './date'
 import errors from './errors'
@@ -7,6 +8,7 @@ import route from './route'
 import viewBounds from './viewBounds'
 
 const reducers = combineReducers({
+  app,
   config,
   date,
   errors,

--- a/src/store/reducers/index.js
+++ b/src/store/reducers/index.js
@@ -4,13 +4,15 @@ import date from './date'
 import errors from './errors'
 import map from './map'
 import route from './route'
+import viewBounds from './viewBounds'
 
 const reducers = combineReducers({
   config,
   date,
   errors,
   map,
-  route
+  route,
+  viewBounds
 })
 
 export default reducers

--- a/src/store/reducers/route.js
+++ b/src/store/reducers/route.js
@@ -6,7 +6,7 @@ import {
   INSERT_ROUTE_WAYPOINT,
   SET_ROUTE,
   SET_ROUTE_ERROR,
-  CLEAR_ANALYSIS_MODE
+  CLEAR_ANALYSIS
 } from '../actions'
 
 const initialState = {
@@ -61,7 +61,7 @@ const route = (state = initialState, action) => {
         lineCoordinates: [],
         error: action.error
       }
-    case CLEAR_ANALYSIS_MODE:
+    case CLEAR_ANALYSIS:
       return initialState
     default:
       return state

--- a/src/store/reducers/viewBounds.js
+++ b/src/store/reducers/viewBounds.js
@@ -1,4 +1,4 @@
-import { SET_VIEW_BOUNDS, CLEAR_VIEW_BOUNDS } from '../actions'
+import { SET_VIEW_BOUNDS, CLEAR_VIEW_BOUNDS, CLEAR_ANALYSIS } from '../actions'
 
 const initialState = {
   bounds: null
@@ -12,10 +12,8 @@ const viewBounds = (state = initialState, action) => {
         bounds: action.bounds
       }
     case CLEAR_VIEW_BOUNDS:
-      return {
-        ...state,
-        bounds: null
-      }
+    case CLEAR_ANALYSIS:
+      return initialState
     default:
       return state
   }

--- a/src/store/reducers/viewBounds.js
+++ b/src/store/reducers/viewBounds.js
@@ -1,0 +1,37 @@
+// Actions
+const SET_BOUNDS = 'analyst-ui/viewBounds/SET_BOUNDS'
+const CLEAR_BOUNDS = 'analyst-ui/viewBounds/CLEAR_BOUNDS'
+
+// Reducer
+const initialState = {
+  bounds: null
+}
+
+export default function reducer (state = initialState, action) {
+  switch (action.type) {
+    case SET_BOUNDS:
+      return {
+        ...state,
+        bounds: action.bounds
+      }
+    case CLEAR_BOUNDS:
+      return {
+        ...state,
+        bounds: null
+      }
+    default:
+      return state
+  }
+}
+
+// Action creators
+export function setBounds (bounds) {
+  return {
+    type: SET_BOUNDS,
+    bounds
+  }
+}
+
+export function clearBounds () {
+  return { type: CLEAR_BOUNDS }
+}

--- a/src/store/reducers/viewBounds.js
+++ b/src/store/reducers/viewBounds.js
@@ -1,20 +1,17 @@
-// Actions
-const SET_BOUNDS = 'analyst-ui/viewBounds/SET_BOUNDS'
-const CLEAR_BOUNDS = 'analyst-ui/viewBounds/CLEAR_BOUNDS'
+import { SET_VIEW_BOUNDS, CLEAR_VIEW_BOUNDS } from '../actions'
 
-// Reducer
 const initialState = {
   bounds: null
 }
 
-export default function reducer (state = initialState, action) {
+const viewBounds = (state = initialState, action) => {
   switch (action.type) {
-    case SET_BOUNDS:
+    case SET_VIEW_BOUNDS:
       return {
         ...state,
         bounds: action.bounds
       }
-    case CLEAR_BOUNDS:
+    case CLEAR_VIEW_BOUNDS:
       return {
         ...state,
         bounds: null
@@ -24,14 +21,4 @@ export default function reducer (state = initialState, action) {
   }
 }
 
-// Action creators
-export function setBounds (bounds) {
-  return {
-    type: SET_BOUNDS,
-    bounds
-  }
-}
-
-export function clearBounds () {
-  return { type: CLEAR_BOUNDS }
-}
+export default viewBounds


### PR DESCRIPTION
There's now a super-simple selection toggle between route and region mode in the sidebar. This should be good enough to show desired functionality, with opportunities for improvement in the future. There's also a "clear" button which erases the current selected region/route. (Resolves #8, #26).

In addition, we have the beginnings of experimental workflow to download trace attributes and tile URLs for the desired route/view. (See #22, #24.)


