### PR TITLE
Clear analysis modal

### DIFF
--- a/src/components/DatePickerContainer/DatePickerContainer.css
+++ b/src/components/DatePickerContainer/DatePickerContainer.css
@@ -3,3 +3,7 @@
 	border-top: 1px solid #dce0e0;
 	color: #484848;
 }
+
+.DateRangePicker__picker {
+  z-index: 3;
+}

--- a/src/components/MapSearchBar/index.js
+++ b/src/components/MapSearchBar/index.js
@@ -167,6 +167,7 @@ class MapSearchBar extends React.Component {
     // Display search bar and expand search icon size when clicked on
     inputContainer.classList.toggle('search-bar__expanded')
     searchButton.classList.toggle('search-bar__expanded')
+    this.autosuggestBar.input.focus()
   }
 
   render () {

--- a/src/components/MapSearchBar/index.js
+++ b/src/components/MapSearchBar/index.js
@@ -179,9 +179,7 @@ class MapSearchBar extends React.Component {
 
     return (
       <div className="map-search-panel">
-        <Button icon size="tiny" className="search-button" onClick={this.handleClick} ref="searchButton">
-          <Icon name="search" className="search-icon" />
-        </Button>
+        <Button icon="search" size="tiny" className="search-button" onClick={this.handleClick} ref="searchButton" />
         <form ref="searchBar" onSubmit={this.handleSubmit} className="inputContainer">
           <Autosuggest
             ref={(ref) => { this.autosuggestBar = ref }}

--- a/src/components/Sidebar/ModeSelect/index.js
+++ b/src/components/Sidebar/ModeSelect/index.js
@@ -1,8 +1,8 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
-import { Segment, Header, Button } from 'semantic-ui-react'
 import { startDrawingBounds } from '../../../app/region-bounds'
+import { Confirm, Segment, Header, Button } from 'semantic-ui-react'
 import * as app from '../../../store/actions/app'
 import { resetAnalysis } from '../../../store/actions/reset'
 
@@ -15,9 +15,24 @@ class ModeSelect extends React.PureComponent {
   constructor (props) {
     super(props)
 
+    this.state = {
+      open: false
+    }
+
     this.onClickRegion = this.onClickRegion.bind(this)
     this.onClickRoute = this.onClickRoute.bind(this)
     this.onClickClearAnalysis = this.onClickClearAnalysis.bind(this)
+    this.handleCancel = this.handleCancel.bind(this)
+    this.handleConfirm = this.handleConfirm.bind(this)
+  }
+
+  handleCancel () {
+    this.setState({open: false})
+  }
+
+  handleConfirm () {
+    this.setState({open: false})
+    this.props.dispatch(resetAnalysis())
   }
 
   onClickRegion (event) {
@@ -32,7 +47,14 @@ class ModeSelect extends React.PureComponent {
   }
 
   onClickClearAnalysis (event) {
-    this.props.dispatch(resetAnalysis())
+    const routeExists = this.props.route.length > 0
+    const regionExists = this.props.region !== null
+    // If route is drawn or region is drawn, have user confirm to clear analysis
+    if (routeExists || regionExists) {
+      this.setState({open: true})
+    } else { // Else if route/region is not drawn but was clicked, turn off mode
+      this.props.dispatch(resetAnalysis())
+    }
   }
 
   render () {
@@ -64,6 +86,13 @@ class ModeSelect extends React.PureComponent {
           basic
           style={{ marginTop: '0.5em' }}
         />
+        <Confirm
+          header="Clear analysis"
+          content={'Are you sure you want to clear your ' + this.props.activeMode + '?'}
+          open={this.state.open}
+          onCancel={this.handleCancel}
+          onConfirm={this.handleConfirm}
+        />
       </Segment>
     )
   }
@@ -71,7 +100,9 @@ class ModeSelect extends React.PureComponent {
 
 function mapStateToProps (state) {
   return {
-    activeMode: state.app.analysisMode
+    activeMode: state.app.analysisMode,
+    route: state.route.waypoints,
+    region: state.viewBounds.bounds
   }
 }
 

--- a/src/components/Sidebar/ModeSelect/index.js
+++ b/src/components/Sidebar/ModeSelect/index.js
@@ -1,8 +1,8 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
-import { startDrawingBounds } from '../../../app/region-bounds'
 import { Confirm, Segment, Header, Button } from 'semantic-ui-react'
+import { startDrawingBounds } from '../../../app/region-bounds'
 import * as app from '../../../store/actions/app'
 import { resetAnalysis } from '../../../store/actions/reset'
 
@@ -16,7 +16,8 @@ class ModeSelect extends React.PureComponent {
     super(props)
 
     this.state = {
-      open: false
+      open: false,
+      case: null
     }
 
     this.onClickRegion = this.onClickRegion.bind(this)
@@ -27,23 +28,50 @@ class ModeSelect extends React.PureComponent {
   }
 
   handleCancel () {
-    this.setState({open: false})
+    this.setState({
+      open: false,
+      case: null
+    })
   }
 
   handleConfirm () {
     this.setState({open: false})
     this.props.dispatch(resetAnalysis())
+    // Check what button was clicked to handle action
+    if (this.state.case === 'region') {
+      this.props.dispatch(app.setRegionAnalysisMode())
+      startDrawingBounds()
+    } else if (this.state.case === 'route') {
+      this.props.dispatch(app.setRouteAnalysisMode())
+    }
+    this.setState({case: null})
   }
 
   onClickRegion (event) {
-    this.props.dispatch(resetAnalysis())
-    this.props.dispatch(app.setRegionAnalysisMode())
-    startDrawingBounds()
+    const routeExists = this.props.route.length > 0
+    // If region button is clicked but selected route exists, have user confirm to clear route
+    if (this.props.activeMode !== null && routeExists) {
+      this.setState({
+        open: true,
+        case: 'region'
+      })
+    } else { // Else allow region to be drawn
+      this.props.dispatch(app.setRegionAnalysisMode())
+      startDrawingBounds()
+    }
   }
 
   onClickRoute (event) {
-    this.props.dispatch(resetAnalysis())
-    this.props.dispatch(app.setRouteAnalysisMode())
+    const regionExists = this.props.region !== null
+    // If route button is clicked but selected region exists, have user confirm to clear region
+    if (this.props.activeMode !== null && regionExists) {
+      this.setState({
+        open: true,
+        case: 'route'
+      })
+    } else { // Else if route button is clicked and no region exists, change mode
+      this.props.dispatch(app.setRouteAnalysisMode())
+    }
   }
 
   onClickClearAnalysis (event) {
@@ -51,7 +79,10 @@ class ModeSelect extends React.PureComponent {
     const regionExists = this.props.region !== null
     // If route is drawn or region is drawn, have user confirm to clear analysis
     if (routeExists || regionExists) {
-      this.setState({open: true})
+      this.setState({
+        open: true,
+        case: 'clear analysis'
+      })
     } else { // Else if route/region is not drawn but was clicked, turn off mode
       this.props.dispatch(resetAnalysis())
     }


### PR DESCRIPTION
Now when you click the clear analysis button, if there is a region/route selected, a modal will appear to confirm your decision (used semantic-ui's confirmation modal). If there is no region/route selected, just the mode, the modal will not appear and the mode will be deselected automatically. 
(Resolves issue #44)