### PR TITLE
Fixed safari problem

### DIFF
--- a/src/components/AnalysisName.js
+++ b/src/components/AnalysisName.js
@@ -41,6 +41,7 @@ class AnalysisName extends React.Component {
   }
 
   handleSubmit (event) {
+    event.preventDefault()
     const input = this.refs.viewName.inputRef.value
     this.setState({ isEditing: false })
     this.props.dispatch(app.setAnalysisName(input))


### PR DESCRIPTION
In Safari, when analysis name is submitted, the page refreshes and loses its value. This only happens in Safari but event.preventDefault() stops this from happening.