### PR TITLE
Leaflet zoom styling

### DIFF
--- a/src/components/Map/Map.css
+++ b/src/components/Map/Map.css
@@ -16,6 +16,28 @@
   color: #ddd;
 }
 
+.leaflet-top .leaflet-control {
+  margin-top: 55px;
+}
+
+.leaflet-top {
+  z-index: 800;
+}
+
+.leaflet-control-zoom-in {
+  width: 30px !important;
+  height: 30px !important;
+  line-height: 30px !important;
+  font-size: 22px !important;
+}
+
+.leaflet-control-zoom-out {
+  width: 30px !important;
+  height: 30px !important;
+  line-height: 30px !important;
+  font-size: 24px !important;
+}
+
 .map-bounding-box-disabled {
   cursor: inherit;
 }

--- a/src/components/Map/Map.css
+++ b/src/components/Map/Map.css
@@ -24,17 +24,24 @@
   z-index: 800;
 }
 
-.leaflet-control-zoom-in {
+/* leaflet-touch styling for zoom buttons */
+.leaflet-bar {
+  border: solid 2px rgba(0,0,0,0.2) !important;
+  background-clip: padding-box !important;
+  box-shadow: none !important;
+}
+
+.leaflet-bar a {
   width: 30px !important;
   height: 30px !important;
   line-height: 30px !important;
+}
+
+.leaflet-control-zoom-in {
   font-size: 22px !important;
 }
 
 .leaflet-control-zoom-out {
-  width: 30px !important;
-  height: 30px !important;
-  line-height: 30px !important;
   font-size: 24px !important;
 }
 

--- a/src/components/MapSearchBar/MapSearchBar.css
+++ b/src/components/MapSearchBar/MapSearchBar.css
@@ -43,14 +43,6 @@ i.icon.search-icon {
   color: #c9caca;
 }
 
-.leaflet-top .leaflet-control {
-  margin-top: 55px;
-}
-
-.leaflet-top {
-  z-index: 800;
-}
-
 .inputContainer {
   display: none;
 }


### PR DESCRIPTION
Safari and Mozilla are not applying leaflet-touch stylings to the zoom controls which leads to different sizing of zoom controls from Chrome and the zoom controls not matching the search button (Issue #49) 

As a solution, I overrided the default leaflet stylings for the zoom controls to always be what the leaflet-touch class has. 