### PR TITLE
found bug where region is no longer cleared when bounds are null

### DIFF
--- a/src/app/region.js
+++ b/src/app/region.js
@@ -80,7 +80,7 @@ function getBboxArea (bounds) {
   return area
 }
 
-function clearRegion () {
+export function clearRegion () {
   const scene = getCurrentScene()
   delete scene.sources.routes
   setCurrentScene(scene)

--- a/src/components/MapContainer.js
+++ b/src/components/MapContainer.js
@@ -19,7 +19,7 @@ import {
 } from '../store/actions/route'
 import { updateScene } from '../store/actions/tangram'
 import { drawBounds } from '../app/region-bounds'
-import { showRegion } from '../app/region'
+import { showRegion, clearRegion } from '../app/region'
 import { showRoute } from '../app/route'
 
 const ROUTE_ZOOM_LEVEL = 10
@@ -58,6 +58,7 @@ class MapContainer extends React.Component {
         isEqual(prevProps.bounds, this.props.bounds)) return
 
     if (this.props.bounds === null) {
+      clearRegion()
       showRoute(this.props.route.waypoints)
     } else {
       showRegion(this.props.bounds)


### PR DESCRIPTION
This is because showRegion is no longer called when bounds are null
Exported clearRegion() to deal with bug in mapContainer.js before showRoute() is called when component is updated. 