### PR TITLE
when exporting GeoJSON files, include info on analysis mode, bounds, date, etc.

### DIFF
--- a/src/app/region.js
+++ b/src/app/region.js
@@ -141,6 +141,12 @@ export function showRegion (bounds) {
                 addSpeedToThing(tiles, date, item, features[index].properties)
               })
               setDataSource('routes', { type: 'GeoJSON', data: results })
+              results.properties = {
+                analysisMode: 'region',
+                analyisName: store.getState().app.viewName,
+                bounds: store.getState().view.bounds,
+                date: store.getState().date
+              }
               store.dispatch(setGeoJSON(results))
               store.dispatch(stopLoading())
             })

--- a/src/app/route.js
+++ b/src/app/route.js
@@ -105,7 +105,12 @@ export function showRoute (waypoints) {
         const speeds = []
         const geojson = {
           type: 'FeatureCollection',
-          features: []
+          features: [],
+          properties: {
+            analysisMode: 'route',
+            analyisName: store.getState().app.viewName,
+            date: store.getState().date
+          }
         }
 
         response.edges.forEach(function (edge, index) {


### PR DESCRIPTION
GeoJSON export: query properties

related to #123 