### PR TITLE
handle 8-bit conversion

### DIFF
--- a/src/app/tangram-scene.js
+++ b/src/app/tangram-scene.js
@@ -1,6 +1,6 @@
 /* global feature */
 import config from '../config'
-import { STOPS, ZERO_SPEED_STOPS } from '../lib/route-segments'
+import { STOPS, ZERO_SPEED_STOPS, OUTLINE_STOPS, ZERO_SPEED_OUTLINE_STOPS } from '../lib/route-segments'
 import { getColorAtIndexInVec3 } from '../lib/color-ramps'
 
 const scene = {

--- a/src/app/tangram-scene.js
+++ b/src/app/tangram-scene.js
@@ -1,6 +1,6 @@
 /* global feature */
 import config from '../config'
-import { STOPS, ZERO_SPEED_STOPS, OUTLINE_STOPS, ZERO_SPEED_OUTLINE_STOPS } from '../lib/route-segments'
+import { STOPS, OUTLINE_STOPS } from '../lib/route-segments'
 import { getColorAtIndexInVec3 } from '../lib/color-ramps'
 
 const scene = {

--- a/src/app/tangram-scene.js
+++ b/src/app/tangram-scene.js
@@ -38,7 +38,8 @@ const scene = {
                           : speed > 0 ? 1 / 15
                           : 0
               return [ colorIndex, feature.drive_on_right, feature.oneway ]
-            }
+            },
+            cap: 'round'
           }
         },
         otOutlines: {

--- a/src/app/tangram-scene.js
+++ b/src/app/tangram-scene.js
@@ -6,7 +6,8 @@ import { getColorAtIndexInVec3 } from '../lib/color-ramps'
 const scene = {
   import: [
     'https://mapzen.com/carto/refill-style/7/refill-style.zip',
-    'https://mapzen.com/carto/refill-style/7/themes/gray.zip',
+    'https://mapzen.com/carto/refill-style/7/themes/gray.zip'
+  ],
   global: {
     'sdk_mapzen_api_key': config.mapzen.apiKey
   },

--- a/src/app/tangram-scene.js
+++ b/src/app/tangram-scene.js
@@ -25,16 +25,17 @@ const scene = {
           width: STOPS,
           color: function () {
             const speed = feature.speed
-            const colorIndex = speed >= 100 ? 10 / 10
-                        : speed >= 90 ? 9 / 10
-                        : speed >= 80 ? 8 / 10
-                        : speed >= 70 ? 7 / 10
-                        : speed >= 60 ? 6 / 10
-                        : speed >= 50 ? 5 / 10
-                        : speed >= 40 ? 4 / 10
-                        : speed >= 30 ? 3 / 10
-                        : speed >= 20 ? 2 / 10
-                        : speed > 0 ? 1 / 10
+            // divide by an even multiple of 255 for lossless conversion to 8 bits
+            const colorIndex = speed >= 100 ? 10 / 15
+                        : speed >= 90 ? 9 / 15
+                        : speed >= 80 ? 8 / 15
+                        : speed >= 70 ? 7 / 15
+                        : speed >= 60 ? 6 / 15
+                        : speed >= 50 ? 5 / 15
+                        : speed >= 40 ? 4 / 15
+                        : speed >= 30 ? 3 / 15
+                        : speed >= 20 ? 2 / 15
+                        : speed > 0 ? 1 / 15
                         : 0
             return [ colorIndex, feature.drive_on_right, feature.oneway ]
           },
@@ -81,7 +82,8 @@ const scene = {
           color: `
             // Speed to color from palette LUT
             // color = texture2D(u_palette, vec2(clamp(v_color.r,0.,1.),.5));
-            int i = int(floor(v_color.r * 10.));
+            int i = int(floor(v_color.r * 15.));
+
             if (i == 0) color.rgb = vec3(${getColorAtIndexInVec3(0)});
             if (i == 1) color.rgb = vec3(${getColorAtIndexInVec3(1)});
             if (i == 2) color.rgb = vec3(${getColorAtIndexInVec3(2)});

--- a/src/app/tangram-scene.js
+++ b/src/app/tangram-scene.js
@@ -7,11 +7,6 @@ const scene = {
   import: [
     'https://mapzen.com/carto/refill-style/7/refill-style.zip',
     'https://mapzen.com/carto/refill-style/7/themes/gray.zip',
-    // 'https://mapzen.com/carto/refill-style/7/themes/gray-gold.zip'
-    'https://tangrams.github.io/blocks/functions/zoom.yaml',
-    'https://tangrams.github.io/blocks/functions/aastep.yaml',
-    'https://tangrams.github.io/blocks/generative/random.yaml'
-  ],
   global: {
     'sdk_mapzen_api_key': config.mapzen.apiKey
   },
@@ -62,26 +57,13 @@ const scene = {
   styles: {
     otRoads: {
       base: 'lines',
-      mix: ['functions-zoom', 'functions-aastep', 'generative-random'],
       texcoords: true,
       lighting: false,
       blend: 'inlay',
       shaders: {
-        defines: {
-          ZOOM_START: 18,
-          ZOOM_END: 20,
-          ZOOM_IN: 0,
-          ZOOM_OUT: 0.5
-        },
-        uniforms: {
-          u_palette: 'palette'
-        },
         blocks: {
-          // One or two lanes
-          width: 'width *= v_texcoord.x;',
           color: `
-            // Speed to color from palette LUT
-            // color = texture2D(u_palette, vec2(clamp(v_color.r,0.,1.),.5));
+            // convert back to ints from 8-bit floats
             int i = int(floor(v_color.r * 15.));
 
             if (i == 0) color.rgb = vec3(${getColorAtIndexInVec3(0)});

--- a/src/app/tangram-scene.js
+++ b/src/app/tangram-scene.js
@@ -13,44 +13,59 @@ const scene = {
   layers: {
     routes: {
       data: { source: 'routes' },
-      draw: {
-        otRoads: {
-          interactive: true,
-          order: 500,
-          width: STOPS,
-          color: function () {
-            const speed = feature.speed
-            // divide by an even multiple of 255 for lossless conversion to 8 bits
-            const colorIndex = speed >= 100 ? 10 / 15
-                        : speed >= 90 ? 9 / 15
-                        : speed >= 80 ? 8 / 15
-                        : speed >= 70 ? 7 / 15
-                        : speed >= 60 ? 6 / 15
-                        : speed >= 50 ? 5 / 15
-                        : speed >= 40 ? 4 / 15
-                        : speed >= 30 ? 3 / 15
-                        : speed >= 20 ? 2 / 15
-                        : speed > 0 ? 1 / 15
-                        : 0
-            return [ colorIndex, feature.drive_on_right, feature.oneway ]
-          },
-          outline: {
-            width: '1px',
-            color: '#222'
-          },
-          join: 'round'
-        }
-      },
-      zeroSpeed: {
-        filter: function () {
-          return feature.speed === 0 || feature.speed === null || typeof feature.speed === 'undefined'
-        },
+      nonzero: {
+        // filter: function() {
+        //   return feature.speed !== 0 && feature.speed !== null && typeof feature.speed !== 'undefined'
+        // },
         draw: {
-          lines: {
-            order: 400,
-            width: ZERO_SPEED_STOPS
+          otRoads: {
+            interactive: true,
+            order: 500,
+            width: STOPS,
+            color: function () {
+              const speed = feature.speed
+              // divide by an even multiple of 255 for lossless conversion to 8 bits
+              const colorIndex = speed >= 100 ? 10 / 15
+                          : speed >= 90 ? 9 / 15
+                          : speed >= 80 ? 8 / 15
+                          : speed >= 70 ? 7 / 15
+                          : speed >= 60 ? 6 / 15
+                          : speed >= 50 ? 5 / 15
+                          : speed >= 40 ? 4 / 15
+                          : speed >= 30 ? 3 / 15
+                          : speed >= 20 ? 2 / 15
+                          : speed > 0 ? 1 / 15
+                          : 0
+              return [ colorIndex, feature.drive_on_right, feature.oneway ]
+            }
+          }
+        },
+        otOutlines: {
+          draw: {
+            otOutlines: {
+              order: 499,
+              width: OUTLINE_STOPS,
+              color: '#222'
+            }
           }
         }
+      // },
+      // zeroSpeed: {
+      //   filter: function () {
+      //     return feature.speed === 0 || feature.speed === null || typeof feature.speed === 'undefined'
+      //   },
+      //   draw: {
+      //     lines: {
+      //       order: 400,
+      //       width: STOPS,
+      //       color: '#ccc',
+      //       outline: {
+      //         width: '.5px',
+      //         color: '#222'
+      //       },
+      //       join: 'round'
+      //     }
+      //   }
       }
     }
   },
@@ -78,15 +93,18 @@ const scene = {
             if (i == 9) color.rgb = vec3(${getColorAtIndexInVec3(9)});
             if (i == 10) color.rgb = vec3(${getColorAtIndexInVec3(10)});
 
-            // Scale down the road x2
-            vec2 st = fract(v_texcoord.xy*2.)+vec2(.5,0.);
-            // Flip direction if the the drive is not on the right.
-            st.y = mix(st.y,1.-fract(st.y),v_color.g);
-            // Adjust the speed to the speed
-            // st.y -= u_time*5.*v_color.r;
-            // Make chrevone arrow just in the second line
-            // color.a *= min(floor(v_texcoord.x*2.),
-            //                 aastep(zoom(),fract(st.y+abs(st.x*.5-.5))));`
+            // draw each half-width if it's not a one-way street
+            color.a = floor(v_texcoord.x*2.)+v_color.b;
+          `
+        }
+      }
+    },
+    otOutlines: {
+      base: 'lines',
+      mix: 'otRoads',
+      shaders: {
+        blocks: {
+          color: `color = v_color;`
         }
       }
     }

--- a/src/lib/route-segments.js
+++ b/src/lib/route-segments.js
@@ -1,7 +1,7 @@
 export const STOPS = [[15, '3px'], [17, '4px'], [18, '10px'], [20, '45px']]
 // outline is the same line + 2px width, to give 1px on either side
 export const OUTLINE_STOPS = [[15, '3px'], [17, '5px'], [18, '12px'], [20, '47px']]
-export const ZERO_SPEED_STOPS = [[15, '0.5px'], [17, '1px'], [18, '2.5px'], [20, '11.25px']]
+// export const ZERO_SPEED_STOPS = [[15, '0.5px'], [17, '1px'], [18, '2.5px'], [20, '11.25px']]
 // export const ZERO_SPEED_OUTLINE_STOPS = [[15, '0px'], [17, '2px'], [18, '3.5px'], [20, '12.25px']]
 
 // Calculate the slope and y-intercept in order to get linear equation
@@ -19,7 +19,8 @@ export function getLinearValue (x, y, c, d, zoom) {
 // Replicating how tangram "stops" data structure works
 export function getSegmentWidth (zoom, speed) {
   // If speed is less than or equal to zero, or not present, use zeroSpeed stops for less weight
-  const array = (speed <= 0 || speed === null || typeof speed === 'undefined') ? ZERO_SPEED_STOPS : STOPS
+  // const array = (speed <= 0 || speed === null || typeof speed === 'undefined') ? ZERO_SPEED_STOPS : STOPS
+  const array = STOPS
   const startValue = array[0]
   const endValue = array[array.length - 1]
   // If zoom values are outside the defined range,

--- a/src/lib/route-segments.js
+++ b/src/lib/route-segments.js
@@ -1,5 +1,8 @@
 export const STOPS = [[15, '3px'], [17, '4px'], [18, '10px'], [20, '45px']]
+// outline is the same line + 2px width, to give 1px on either side
+export const OUTLINE_STOPS = [[15, '3px'], [17, '5px'], [18, '12px'], [20, '47px']]
 export const ZERO_SPEED_STOPS = [[15, '0.5px'], [17, '1px'], [18, '2.5px'], [20, '11.25px']]
+// export const ZERO_SPEED_OUTLINE_STOPS = [[15, '0px'], [17, '2px'], [18, '3.5px'], [20, '12.25px']]
 
 // Calculate the slope and y-intercept in order to get linear equation
 // Values given as params are (x, y) and (c, d)


### PR DESCRIPTION
When v_color is converted to 8 bits, precision is lost – so the value `.1` was converted to `25/255` by the gpu, and the shader identified `int(floor(0.098039215686275 * 10.))` as `0`.

If we divide by a factor of 255 larger than our largest value of 10, which would be 15, then we can convert our range into values within [0..1] which will survive the 8-bit conversion and "re-inflate" properly in the shader.

Fixes https://github.com/opentraffic/analyst-ui/issues/144