### PR TITLE
GeoJSON export

### DIFF
--- a/src/app/processing.js
+++ b/src/app/processing.js
@@ -24,9 +24,32 @@ export function addSpeedToMapGeometry (tiles, date, segment, geometry) {
     const subtile = getSubtileForSegmentIdx(segment.segmentIdx, subtiles)
     if (subtile) {
       // Append the speed to the geometry to render later
+      const speeds = getValuesFromSubtile(segment.segmentIdx, subtile, days, hours, 'speeds')
+      geometry.speedByHour = addSpeedByHour(speeds, days, hours)
       geometry.speed = getMeanSpeed(segment.segmentIdx, subtile, days, hours)
     }
   } catch (e) {}
+}
+
+function addSpeedByHour (speedArray, days, hours) {
+  const speedByHour = []
+  const dayStart = days[0] + 1
+  const hourStart = hours[0] + 1
+  const hourEnd = hours[1]
+
+  let day = dayStart
+  let hour = hourStart
+
+  speedArray.forEach((speed, index) => {
+    hour = (hour % hourEnd === 0 || index === 0) ? hourStart : hour + 1
+    day = (hour !== hourStart || index === 0) ? day : day + 1
+    speedByHour.push({
+      'dayOfWeek': day,
+      'hourOfDay': hour,
+      'speedThisHour': speed
+    })
+  })
+  return speedByHour
 }
 
 /**

--- a/src/app/route.js
+++ b/src/app/route.js
@@ -198,6 +198,7 @@ export function showRoute (waypoints) {
           let coordsSlice = coordinates.slice(begin, end + 1)
           const fullArrayDist = Distance(coordsSlice[0], coordsSlice[coordsSlice.length - 1])
           let speed = -1
+          let speedByHour = []
           let dist = 0
           if (edge.traffic_segments) {
             for (let t = 0; t < edge.traffic_segments.length; t++) {
@@ -245,6 +246,7 @@ export function showRoute (waypoints) {
               for (let i = 0; i < parsedIds.length; i++) {
                 if (id === parsedIds[i].id) {
                   speed = parsedIds[i].speed
+                  speedByHour = parsedIds[i].speedByHour
                   speeds.push({
                     coordinates: coordsSlice,
                     speed: speed,
@@ -253,6 +255,7 @@ export function showRoute (waypoints) {
                   break
                 }
               }
+
               // Make geoJSON feature
               // coordinates in GeoJSON must flip lat/lng values
               const coordsGeo = coordsSlice.map((i) => [i[1], i[0]])
@@ -265,7 +268,8 @@ export function showRoute (waypoints) {
                 properties: {
                   id: edge.traffic_segments[t],
                   osmlr_id: edge.traffic_segments[t].segment_id,
-                  speed: speed
+                  speed: speed,
+                  speedByHour: speedByHour
                   // Note, this is missing properties that are already there in the region view
                 }
               })

--- a/src/config.js
+++ b/src/config.js
@@ -7,7 +7,7 @@ const config = {
     center: [0, 120],
     zoom: 3
   },
-  osmlrTileUrl: 'https://osmlr-tiles.s3.amazonaws.com/v1.0/geojson/',
+  osmlrTileUrl: 'https://osmlr-tiles.s3.amazonaws.com/v1.1/geojson/',
   dataGeojson: 'https://s3.amazonaws.com/referencetiles-prod/coverage_map.geojson',
   historicSpeedTileUrl: 'https://speedtiles-prod.s3-accelerate.amazonaws.com/',
   nextSegmentTileUrl: 'https://speedtiles-prod.s3-accelerate.amazonaws.com/',


### PR DESCRIPTION
At each segment, geoJSON export now includes property `speedByHour` which consists of an array of objects that has `dayOfWeek`, `hourOfDay`, and `speedThisHour`. 

Resolves issue #151 