### PR TITLE
Hanb/pass compare var to tangram

### DIFF
--- a/src/components/Map/TangramLayer/index.js
+++ b/src/components/Map/TangramLayer/index.js
@@ -53,10 +53,11 @@ export default class TangramLayer extends GridLayer {
     return false
   }
 
-
-    componentWillReceiveProps(nextProps) {
-    this.tangram.scene.config.global.refSpeedComparisonEnabled = nextProps.refSpeedComparisonEnabled;
-    this.tangram.scene.updateConfig();
+  componentWillReceiveProps (nextProps) {
+    if (this.props.refSpeedComparisonEnabled !== nextProps.refSpeedComparisonEnabled) {
+      this.tangram.scene.config.global.refSpeedComparisonEnabled = nextProps.refSpeedComparisonEnabled
+      this.tangram.scene.updateConfig()
+    }
   }
 
   createLeafletElement (props) {

--- a/src/components/Map/TangramLayer/index.js
+++ b/src/components/Map/TangramLayer/index.js
@@ -4,21 +4,21 @@ import PropTypes from 'prop-types'
 import { GridLayer } from 'react-leaflet'
 // import { isEqual } from 'lodash'
 import { storeReferenceToTangramLayer } from '../../../lib/tangram'
-
 // Extends react-leaflet's GridLayer and wraps Tangram so it works as a
 // React component in react-leaflet
+
 export default class TangramLayer extends GridLayer {
   static propTypes = {
     scene: PropTypes.oneOfType([
       PropTypes.string,
       PropTypes.object
     ]),
+    refSpeedComparisonEnabled: PropTypes.bool,
     attribution: PropTypes.string
   }
 
   constructor (props) {
     super(props)
-
     this.tangram = null
   }
 
@@ -53,9 +53,14 @@ export default class TangramLayer extends GridLayer {
     return false
   }
 
+
+    componentWillReceiveProps(nextProps) {
+    this.tangram.scene.config.global.refSpeedComparisonEnabled = nextProps.refSpeedComparisonEnabled;
+    this.tangram.scene.updateConfig();
+  }
+
   createLeafletElement (props) {
     this.tangram = Tangram.leafletLayer(this.getOptions(props))
-
     // Expose to another module for access.
     storeReferenceToTangramLayer(this.tangram)
 

--- a/src/components/Map/TangramLayer/index.js
+++ b/src/components/Map/TangramLayer/index.js
@@ -53,6 +53,10 @@ export default class TangramLayer extends GridLayer {
     return false
   }
 
+  // We are using componentWillRecieveProps here checking the props
+  // affecting Tangram configuration is changed (if so, update Tangram config)
+  // This is the way we came up with to change the config of Tangram
+  // insdie of the related component (TangramLayer), but outside of React lifecycle
   componentWillReceiveProps (nextProps) {
     if (this.props.refSpeedComparisonEnabled !== nextProps.refSpeedComparisonEnabled) {
       this.tangram.scene.config.global.refSpeedComparisonEnabled = nextProps.refSpeedComparisonEnabled

--- a/src/components/Map/index.js
+++ b/src/components/Map/index.js
@@ -17,6 +17,7 @@ export default class Map extends React.Component {
     zoom: PropTypes.number,
     onChange: PropTypes.func,
     onClick: PropTypes.func,
+    refSpeedComparisonEnabled: PropTypes.bool,
     recenterMap: PropTypes.func
   }
 
@@ -42,7 +43,7 @@ export default class Map extends React.Component {
   }
 
   render () {
-    const { className, children, center, zoom, onClick, scene } = this.props
+    const { className, children, center, refSpeedComparisonEnabled, zoom, onClick, scene } = this.props
 
     // The `editable` option is not provided by Leaflet but by Leaflet.Editable.
     // It is passed to the options object via props.
@@ -56,7 +57,10 @@ export default class Map extends React.Component {
         ref={(ref) => { this.map = ref }}
         editable
       >
-        <TangramLayer scene={scene} attribution={ATTRIBUTION} />
+        <TangramLayer
+          refSpeedComparisonEnabled={refSpeedComparisonEnabled}
+          scene={scene}
+          attribution={ATTRIBUTION} />
         <ScaleControl />
         {children}
       </Leaflet>

--- a/src/components/MapContainer.js
+++ b/src/components/MapContainer.js
@@ -102,6 +102,7 @@ class MapContainer extends React.Component {
           zoom={map.zoom}
           onClick={this.onClick}
           recenterMap={this.props.recenterMap}
+          refSpeedComparisonEnabled={this.props.refSpeedComparisonEnabled}
           scene={this.props.scene}
         >
           <Route
@@ -120,6 +121,7 @@ class MapContainer extends React.Component {
 function mapStateToProps (state) {
   return {
     mode: state.app.analysisMode,
+    refSpeedComparisonEnabled: state.app.refSpeedComparisonEnabled,
     apiKey: state.config.mapzen.apiKey,
     route: state.route,
     days: state.date.dayFilter,
@@ -133,7 +135,7 @@ function mapStateToProps (state) {
 }
 
 function mapDispatchToProps (dispatch) {
-  return bindActionCreators({ ...mapActionCreators, setRouteError, clearRouteError, addWaypoint, insertWaypoint, removeWaypoint, updateWaypoint, updateScene }, dispatch)
+  return bindActionCreators({ ...mapActionCreators, setRouteError, clearRouteError, addWaypoint, insertWaypoint, removeWaypoint, updateWaypoint }, dispatch)
 }
 
 export default connect(mapStateToProps, mapDispatchToProps)(MapContainer)

--- a/src/components/MapContainer.js
+++ b/src/components/MapContainer.js
@@ -135,7 +135,7 @@ function mapStateToProps (state) {
 }
 
 function mapDispatchToProps (dispatch) {
-  return bindActionCreators({ ...mapActionCreators, setRouteError, clearRouteError, addWaypoint, insertWaypoint, removeWaypoint, updateWaypoint }, dispatch)
+  return bindActionCreators({ ...mapActionCreators, setRouteError, clearRouteError, addWaypoint, insertWaypoint, removeWaypoint, updateWaypoint, updateScene }, dispatch)
 }
 
 export default connect(mapStateToProps, mapDispatchToProps)(MapContainer)

--- a/src/components/Sidebar/TimeFilters/index.js
+++ b/src/components/Sidebar/TimeFilters/index.js
@@ -5,7 +5,6 @@ import { Segment, Radio, Divider } from 'semantic-ui-react'
 import dc from 'dc'
 import crossfilter from 'crossfilter2'
 import { createChart } from './chart'
-import { getCurrentConfig, setCurrentConfig } from '../../../lib/tangram'
 import { setRefSpeedComparisonEnabled } from '../../../store/actions/app'
 import { setDayFilter, setHourFilter } from '../../../store/actions/date'
 import { isEqual } from 'lodash'
@@ -106,10 +105,6 @@ export class TimeFilters extends React.Component {
               checked={this.props.refSpeedComparisonEnabled}
               onChange={(event, data) => {
                 this.props.dispatch(setRefSpeedComparisonEnabled(data.checked))
-                // set global tangram property, as tangram can't access the store directly
-                const config = getCurrentConfig()
-                config.global.refSpeedComparisonEnabled = data.checked
-                setCurrentConfig(config)
               }}
             />
           </strong>


### PR DESCRIPTION
- `TimeFilters` was doing more things than it is supposed to do. This PR made Radio button only to dispatch `refSpeedComparisonEnabled`. Then MapContainer catches and passes `refSpeedComparisonEnabled` to `TangramLayer`. `TangramLayer` checks this var is changed or not, if it was changed, triggers `updateConfig`.